### PR TITLE
Added new OTP connection 'inline' that allows to generate an inline OTP

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -494,6 +494,7 @@ final class UserController extends OpenIdController
      */
     public function getConsent()
     {
+        Log::debug("UserController::getConsent");
         if (is_null($this->consent_strategy)) {
 
             Log::warning(sprintf("UserController::getConsent consent strategy is null. request %s %s", Request::method(), Request::path()));

--- a/app/Models/OAuth2/Factories/OTPFactory.php
+++ b/app/Models/OAuth2/Factories/OTPFactory.php
@@ -50,6 +50,12 @@ final class OTPFactory
         $otp = new OAuth2OTP($length, $lifetime);
         $otp->setConnection($request->getConnection());
         $otp->setSend($request->getSend());
+
+        // if its inline the OTP lives forever
+        if($otp->getConnection() === OAuth2Protocol::OAuth2PasswordlessConnectionInline){
+            $lifetime = 0 ;
+        }
+
         $otp->setLifetime($lifetime);
         $otp->setNonce($request->getNonce());
         $otp->setRedirectUrl($request->getRedirectUri());
@@ -96,6 +102,12 @@ final class OTPFactory
         $otp->setConnection($payload[OAuth2Protocol::OAuth2PasswordlessConnection]);
         $otp->setSend($payload[OAuth2Protocol::OAuth2PasswordlessSend]);
         $otp->setScope($payload[OAuth2Protocol::OAuth2Protocol_Scope] ?? null);
+
+        // if its inline the OTP lives forever
+        if($otp->getConnection() === OAuth2Protocol::OAuth2PasswordlessConnectionInline){
+            $lifetime = 0 ;
+        }
+
         $otp->setLifetime($lifetime);
         $otp->setNonce($payload[OAuth2Protocol::OAuth2Protocol_Nonce] ?? null);
         $otp->setRedirectUrl($payload[OAuth2Protocol::OAuth2Protocol_RedirectUri] ?? null);

--- a/app/Models/OAuth2/ResourceServer.php
+++ b/app/Models/OAuth2/ResourceServer.php
@@ -212,4 +212,12 @@ class ResourceServer extends BaseEntity
     public function __get($name) {
         return $this->{$name};
     }
+
+    /**
+     * @param Client $client
+     * @return bool
+     */
+    public function canImpersonateClient(Client $client):bool{
+        return true;
+    }
 }

--- a/app/Services/OAuth2/SecurityContextService.php
+++ b/app/Services/OAuth2/SecurityContextService.php
@@ -11,6 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
+use Illuminate\Support\Facades\Log;
 use OAuth2\Models\SecurityContext;
 use OAuth2\Services\ISecurityContextService;
 use Illuminate\Support\Facades\Session;
@@ -28,6 +30,8 @@ final class SecurityContextService implements ISecurityContextService
      */
     public function get()
     {
+        Log::debug("SecurityContextService::get");
+
         $context = new SecurityContext;
 
         $context->setState
@@ -48,6 +52,7 @@ final class SecurityContextService implements ISecurityContextService
      */
     public function save(SecurityContext $security_context)
     {
+        Log::debug("SecurityContextService::save");
         Session::put(self::RequestedUserIdParam, $security_context->getRequestedUserId());
         Session::put(self::RequestedAuthTime, $security_context->isAuthTimeRequired());
         Session::save();
@@ -59,6 +64,7 @@ final class SecurityContextService implements ISecurityContextService
      */
     public function clear()
     {
+        Log::debug("SecurityContextService::clear");
         Session::remove(self::RequestedUserIdParam);
         Session::remove(self::RequestedAuthTime);
         Session::save();

--- a/app/Strategies/DefaultLoginStrategy.php
+++ b/app/Strategies/DefaultLoginStrategy.php
@@ -13,6 +13,7 @@
  **/
 
 use App\libs\Auth\SocialLoginProviders;
+use Illuminate\Support\Facades\Log;
 use Utils\IPHelper;
 use Services\IUserActionService;
 use Utils\Services\IAuthService;
@@ -45,6 +46,8 @@ class DefaultLoginStrategy implements ILoginStrategy
 
     public function getLogin()
     {
+        Log::debug(sprintf("DefaultLoginStrategy::getLogin"));
+
         if (Auth::guest())
             return View::make("auth.login", [
                 'supported_providers' => SocialLoginProviders::buildSupportedProviders()

--- a/app/Strategies/OAuth2ConsentStrategy.php
+++ b/app/Strategies/OAuth2ConsentStrategy.php
@@ -11,6 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use OAuth2\Factories\OAuth2AuthorizationRequestFactory;
 use OAuth2\OAuth2Message;
@@ -65,6 +67,8 @@ class OAuth2ConsentStrategy implements IConsentStrategy
 
     public function getConsent()
     {
+        Log::debug("OAuth2ConsentStrategy::getConsent");
+
         $auth_request = OAuth2AuthorizationRequestFactory::getInstance()->build
         (
             OAuth2Message::buildFromMemento
@@ -72,6 +76,9 @@ class OAuth2ConsentStrategy implements IConsentStrategy
                 $this->memento_service->load()
             )
         );
+
+        Log::debug(sprintf("OAuth2ConsentStrategy::getConsent auth request %s", $auth_request->__toString()));
+
 
         $client_id                = $auth_request->getClientId();
         $client                   = $this->client_repository->getClientById($client_id);

--- a/app/Strategies/OAuth2LoginStrategy.php
+++ b/app/Strategies/OAuth2LoginStrategy.php
@@ -12,6 +12,7 @@
  * limitations under the License.
  **/
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use OAuth2\Factories\OAuth2AuthorizationRequestFactory;
 use OAuth2\OAuth2Message;
 use OAuth2\Requests\OAuth2AuthenticationRequest;
@@ -60,6 +61,8 @@ class OAuth2LoginStrategy extends DefaultLoginStrategy
 
     public function getLogin()
     {
+        Log::debug(sprintf("OAuth2LoginStrategy::getLogin"));
+
         if (!Auth::guest())
             return Redirect::action("UserController@getProfile");
 
@@ -67,6 +70,7 @@ class OAuth2LoginStrategy extends DefaultLoginStrategy
         if (!is_null($requested_user_id)) {
             $userHint = $this->auth_service->getUserById($requested_user_id);
             if(!is_null($userHint)) {
+                Log::debug(sprintf("OAuth2LoginStrategy::getLogin user %s has saved state", $requested_user_id));
                 Session::put('username', $userHint->getEmail());
                 Session::put('user_fullname', $userHint->getFullName());
                 Session::put('user_pic', $userHint->getPic());

--- a/app/Strategies/OTP/OTPChannelNullStrategy.php
+++ b/app/Strategies/OTP/OTPChannelNullStrategy.php
@@ -1,0 +1,29 @@
+<?php namespace App\Strategies\OTP;
+/*
+ * Copyright 2023 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Models\OAuth2\OAuth2OTP;
+
+/**
+ * Class OTPChannelNullStrategy
+ * @package App\Strategies\OTP
+ */
+final class OTPChannelNullStrategy
+    implements IOTPChannelStrategy
+{
+
+    public function send(IOTPTypeBuilderStrategy $typeBuilderStrategy, OAuth2OTP $otp): bool
+    {
+        return true;
+    }
+}

--- a/app/Strategies/OTP/OTPChannelStrategyFactory.php
+++ b/app/Strategies/OTP/OTPChannelStrategyFactory.php
@@ -25,6 +25,8 @@ final class OTPChannelStrategyFactory
         switch($connection){
             case OAuth2Protocol::OAuth2PasswordlessConnectionEmail:
                 return new OTPChannelEmailStrategy();
+            case OAuth2Protocol::OAuth2PasswordlessConnectionInline:
+                return new OTPChannelNullStrategy();
         }
         throw new InvalidOAuth2Request(sprintf("connection value %s is not valid", $connection));
     }

--- a/app/libs/Auth/AuthService.php
+++ b/app/libs/Auth/AuthService.php
@@ -27,6 +27,7 @@ use Models\OAuth2\OAuth2OTP;
 use OAuth2\Exceptions\InvalidOTPException;
 use OAuth2\Models\IClient;
 use OAuth2\Services\IPrincipalService;
+use OAuth2\Services\ISecurityContextService;
 use OpenId\Services\IUserService;
 use App\Services\Auth\IUserService as IAuthUserService;
 use utils\Base64UrlRepresentation;
@@ -73,6 +74,11 @@ final class AuthService extends AbstractService implements IAuthService
     private $otp_repository;
 
     /**
+     * @var ISecurityContextService
+     */
+    private $security_context_service;
+
+    /**
      * AuthService constructor.
      * @param IUserRepository $user_repository
      * @param IOAuth2OTPRepository $otp_repository
@@ -80,6 +86,7 @@ final class AuthService extends AbstractService implements IAuthService
      * @param IUserService $user_service
      * @param ICacheService $cache_service
      * @param IAuthUserService $auth_user_service
+     * @params ISecurityContextService $security_context_service
      * @param ITransactionService $tx_service
      */
     public function __construct
@@ -90,6 +97,7 @@ final class AuthService extends AbstractService implements IAuthService
         IUserService $user_service,
         ICacheService $cache_service,
         IAuthUserService $auth_user_service,
+        ISecurityContextService $security_context_service,
         ITransactionService $tx_service
     )
     {
@@ -100,6 +108,7 @@ final class AuthService extends AbstractService implements IAuthService
         $this->cache_service = $cache_service;
         $this->auth_user_service = $auth_user_service;
         $this->otp_repository = $otp_repository;
+        $this->security_context_service = $security_context_service;
     }
 
     /**
@@ -258,8 +267,9 @@ final class AuthService extends AbstractService implements IAuthService
     {
         Log::debug("AuthService::logout");
         $this->invalidateSession();
-        Auth::logout();
         $this->principal_service->clear();
+        $this->security_context_service->clear();
+        Auth::logout();
         // put in past
         Cookie::queue
         (

--- a/app/libs/OAuth2/GrantTypes/PasswordlessGrantType.php
+++ b/app/libs/OAuth2/GrantTypes/PasswordlessGrantType.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Auth;
 use Models\OAuth2\Client;
 use Models\OAuth2\OAuth2OTP;
 use OAuth2\Exceptions\InvalidApplicationType;
+use OAuth2\Exceptions\InvalidClientCredentials;
 use OAuth2\Exceptions\InvalidClientException;
 use OAuth2\Exceptions\InvalidOAuth2Request;
 use OAuth2\Exceptions\InvalidOTPException;
@@ -39,6 +40,7 @@ use OAuth2\Responses\OAuth2AccessTokenResponse;
 use OAuth2\Responses\OAuth2DirectErrorResponse;
 use OAuth2\Responses\OAuth2IdTokenResponse;
 use OAuth2\Responses\OAuth2PasswordlessAuthenticationResponse;
+use OAuth2\Responses\OAuth2PasswordlessInlineAuthenticationResponse;
 use OAuth2\Responses\OAuth2Response;
 use OAuth2\Services\IApiScopeService;
 use OAuth2\Services\IClientJWKSetReader;
@@ -48,6 +50,7 @@ use OAuth2\Services\IPrincipalService;
 use OAuth2\Services\ISecurityContextService;
 use OAuth2\Services\ITokenService;
 use OAuth2\Services\IUserConsentService;
+use OAuth2\Strategies\ClientAuthContextValidatorFactory;
 use OAuth2\Strategies\IOAuth2AuthenticationStrategy;
 use Utils\Services\IAuthService;
 use Utils\Services\ILogService;
@@ -187,6 +190,14 @@ class PasswordlessGrantType extends InteractiveGrantType
 
         $otp = $this->token_service->createOTPFromRequest($request, $this->client);
 
+        if($otp->getConnection() === OAuth2Protocol::OAuth2PasswordlessConnectionInline)
+            return new OAuth2PasswordlessInlineAuthenticationResponse(
+                $otp->getValue(),
+                $otp->getLength(),
+                $otp->getRemainingLifetime(),
+                $otp->getScope()
+            );
+
         return new OAuth2PasswordlessAuthenticationResponse
         (
             $otp->getLength(),
@@ -256,6 +267,50 @@ class PasswordlessGrantType extends InteractiveGrantType
                 throw new ScopeNotAllowedException($scope);
             }
 
+            if($request->getConnection() === OAuth2Protocol::OAuth2PasswordlessConnectionInline) {
+                // we need to send out the credentials or a resource server
+                // get client credentials from request..
+                $this->client_auth_context = $this->client_service->getCurrentClientAuthInfo();
+                // retrieve client from storage ...
+                $impersonating_client = $this->client_repository->getClientByIdCacheable($this->client_auth_context->getId());
+                if(is_null($impersonating_client)){
+                    throw new InvalidClientException("Invalid impersonating client for inline OTP request");
+                }
+
+                if (!$impersonating_client->isActive() || $impersonating_client->isLocked()) {
+                    throw new LockedClientException
+                    (
+                        sprintf
+                        (
+                            'Client id %s is locked.',
+                            $this->client_auth_context->getId()
+                        )
+                    );
+                }
+
+                if(!$impersonating_client->isResourceServerClient()){
+                    throw new InvalidClientException("Invalid impersonating client for inline OTP request");
+                }
+
+                $resource_server = $impersonating_client->getResourceServer();
+
+                if(!$resource_server->canImpersonateClient($this->client)){
+                    throw new InvalidClientException("Invalid impersonating client for inline OTP request");
+                }
+
+                $this->client_auth_context->setClient($impersonating_client);
+
+                if(!ClientAuthContextValidatorFactory::build($this->client_auth_context)->validate($this->client_auth_context))
+                    throw new InvalidClientCredentials
+                    (
+                        sprintf
+                        (
+                            'Invalid credentials for client id %s.',
+                            $this->client_auth_context->getId()
+                        )
+                    );
+            }
+
             $response = $this->buildResponse($request, false);
             // clear save data ...
             $this->auth_service->clearUserAuthorizationResponse();
@@ -300,6 +355,10 @@ class PasswordlessGrantType extends InteractiveGrantType
 
             if(!$request->isValid()){
                 throw new InvalidOAuth2Request($request->getLastValidationError());
+            }
+
+            if($request->getConnection() === OAuth2Protocol::OAuth2PasswordlessConnectionInline){
+                throw new InvalidOAuth2Request(sprintf( "OTP connection value (%s) not valid on this flow.", OAuth2Protocol::OAuth2PasswordlessConnectionInline));
             }
 
             parent::completeFlow($request);

--- a/app/libs/OAuth2/OAuth2Protocol.php
+++ b/app/libs/OAuth2/OAuth2Protocol.php
@@ -224,9 +224,12 @@ final class OAuth2Protocol implements IOAuth2Protocol
     const OAuth2PasswordlessConnection = 'connection';
     const OAuth2PasswordlessConnectionSMS = 'sms';
     const OAuth2PasswordlessConnectionEmail = 'email';
+    const OAuth2PasswordlessConnectionInline = 'inline';
+
     const ValidOAuth2PasswordlessConnectionValues = [
         self::OAuth2PasswordlessConnectionSMS,
-        self::OAuth2PasswordlessConnectionEmail
+        self::OAuth2PasswordlessConnectionEmail,
+        self::OAuth2PasswordlessConnectionInline,
     ];
 
     const OAuth2PasswordlessSend = 'send';
@@ -543,6 +546,11 @@ final class OAuth2Protocol implements IOAuth2Protocol
      * the phone_number Claim. The use of this parameter is left to the OP's discretion.
      */
     const OAuth2Protocol_LoginHint = 'login_hint';
+
+    /**
+     * Custom Hint to pass the OTP Value to auto login
+     */
+    const OAuth2Protocol_OTP_LoginHint = 'otp_login_hint';
 
     /**
      * Requested Authentication Context Class Reference values. Space-separated string that specifies the acr values

--- a/app/libs/OAuth2/Requests/OAuth2AuthenticationRequest.php
+++ b/app/libs/OAuth2/Requests/OAuth2AuthenticationRequest.php
@@ -93,7 +93,15 @@ class OAuth2AuthenticationRequest extends OAuth2AuthorizationRequest
      */
     public function getLoginHint()
     {
-        return $this->getParam(OAuth2Protocol::OAuth2Protocol_LoginHint);
+        return $this->getParam(OAuth2Protocol::OAuth2Protocol_LoginHint, false);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getOTPLoginHint()
+    {
+        return $this->getParam(OAuth2Protocol::OAuth2Protocol_OTP_LoginHint);
     }
 
     /**
@@ -123,7 +131,6 @@ class OAuth2AuthenticationRequest extends OAuth2AuthorizationRequest
     {
         parent::__construct($auth_request->getMessage());
     }
-
 
     /**
      * Validates current request

--- a/app/libs/OAuth2/Requests/OAuth2Request.php
+++ b/app/libs/OAuth2/Requests/OAuth2Request.php
@@ -41,13 +41,18 @@ abstract class OAuth2Request {
     }
 
     /**
-     * @param string $param
-     * @return null
+     * @param $param
+     * @param bool $decode
+     * @return mixed|string|null
      */
-    public function getParam($param)
+    public function getParam($param, bool $decode = true)
     {
         $value =  $this->message->getParam($param);
-        if(!empty($value)) $value = trim(urldecode($value));
+        if(!empty($value)) {
+            if($decode)
+                $value = urldecode($value);
+            $value = trim($value);
+        }
         return $value;
     }
 

--- a/app/libs/OAuth2/Responses/OAuth2PasswordlessInlineAuthenticationResponse.php
+++ b/app/libs/OAuth2/Responses/OAuth2PasswordlessInlineAuthenticationResponse.php
@@ -11,28 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-use OAuth2\OAuth2Protocol;
-use Utils\Http\HttpContentType;
+
 /**
- * Class OAuth2PasswordlessAuthenticationResponse
+ * Class OAuth2PasswordlessInlineAuthenticationResponse
  * @package OAuth2\Responses
  */
-class OAuth2PasswordlessAuthenticationResponse extends OAuth2DirectResponse
+final class OAuth2PasswordlessInlineAuthenticationResponse
+extends OAuth2PasswordlessAuthenticationResponse
 {
     /**
-     * OAuth2PasswordlessAuthenticationResponse constructor.
+     * @param string $value
      * @param int $otp_length
      * @param int $otp_lifetime
      * @param string|null $scope
      */
-    public function __construct(int $otp_length, int $otp_lifetime, ?string $scope = null)
+    public function __construct(string $value, int $otp_length, int $otp_lifetime, ?string $scope = null)
     {
         // Successful Responses: A server receiving a valid request MUST send a
         // response with an HTTP status code of 200.
-        parent::__construct(self::HttpOkResponse, HttpContentType::Json);
-        $this["otp_length"] = $otp_length;
-        $this["otp_lifetime"] = $otp_lifetime;
-        if(!empty($scope))
-            $this[OAuth2Protocol::OAuth2Protocol_Scope] = $scope;
+        parent::__construct($otp_length, $otp_lifetime, $scope);
+        $this["value"] = $value;
     }
 }

--- a/app/libs/Utils/Services/IAuthService.php
+++ b/app/libs/Utils/Services/IAuthService.php
@@ -60,10 +60,11 @@ interface IAuthService
     /**
      * @param OAuth2OTP $otpClaim
      * @param Client|null $client
+     * @param bool $remember
      * @return OAuth2OTP|null
      * @throws AuthenticationException
      */
-    public function loginWithOTP(OAuth2OTP $otpClaim, ?Client $client = null): ?OAuth2OTP;
+    public function loginWithOTP(OAuth2OTP $otpClaim, ?Client $client = null, bool $remember = false): ?OAuth2OTP;
 
 
     /**

--- a/create_migration.sh
+++ b/create_migration.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+php artisan doctrine:migrations:generate --connection=model

--- a/database/migrations/Version20230125164749.php
+++ b/database/migrations/Version20230125164749.php
@@ -1,0 +1,46 @@
+<?php namespace Database\Migrations;
+/**
+ * Copyright 2023 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+/**
+ * Class Version20230125164749
+ * @package Database\Migrations
+ */
+final class Version20230125164749 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $sql = <<<SQL
+ALTER TABLE oauth2_otp MODIFY `connection` 
+enum(
+'sms',
+'email',
+'inline'
+) default 'email' null;
+SQL;
+        $this->addSql($sql);
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+
+    }
+}

--- a/tests/OIDCPasswordlessTest.php
+++ b/tests/OIDCPasswordlessTest.php
@@ -20,8 +20,10 @@ use jws\IJWS;
 use LaravelDoctrine\ORM\Facades\EntityManager;
 use Models\OAuth2\Client;
 use Models\OAuth2\OAuth2OTP;
+use Models\OAuth2\ResourceServer;
 use OAuth2\OAuth2Protocol;
 use utils\factories\BasicJWTFactory;
+use Utils\Services\IAuthService;
 use Utils\Services\UtilsServiceCatalog;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
@@ -38,6 +40,13 @@ class OIDCPasswordlessTest extends OpenStackIDBaseTest
      */
     public static $client = null;
 
+    /**
+     * @var ResourceServer
+     */
+    public static $resource_server = null;
+
+    public static $client2 = null;
+
     protected function setUp():void
     {
         parent::setUp();
@@ -46,14 +55,25 @@ class OIDCPasswordlessTest extends OpenStackIDBaseTest
 
         $clients = $client_repository->findAll();
 
-
         self::$client = $clients[0];
-
         self::$client->enablePasswordless();
         self::$client->setOtpLifetime(60 * 3);
         self::$client->setOtpLength(6);
         self::$client->setTokenEndpointAuthMethod(OAuth2Protocol::TokenEndpoint_AuthMethod_ClientSecretBasic);
         EntityManager::persist(self::$client);
+
+        self::$client2 = $client_repository->findOneBy(['client_id' => '1234/Vcvr6fvQbH4HyNgwKlfSpkce.openstack.client']);
+        self::$client2->enablePasswordless();
+        self::$client2->setOtpLifetime(60 * 3);
+        self::$client2->setOtpLength(6);
+        EntityManager::persist(self::$client2);
+
+        $resource_server_repository = EntityManager::getRepository(ResourceServer::class);
+
+        self::$resource_server = $resource_server_repository->findOneBy([
+            'friendly_name' => 'test resource server'
+        ]);
+
     }
 
     protected function tearDown():void
@@ -424,6 +444,207 @@ class OIDCPasswordlessTest extends OpenStackIDBaseTest
         $this->assertTrue(!empty($access_token));
         $this->assertTrue(!empty($refresh_token));
         $this->assertTrue(!empty($id_token));
+    }
+
+    public function testCodeInlineFlow() {
+
+        $scope = sprintf('%s profile email address %s',
+            OAuth2Protocol::OpenIdConnect_Scope,
+            OAuth2Protocol::OfflineAccess_Scope
+        );
+
+        $params = [
+            'client_id' => self::$client->getClientId(),
+            'scope' => $scope,
+            OAuth2Protocol::OAuth2Protocol_Nonce => '123456',
+            OAuth2Protocol::OAuth2Protocol_ResponseType => OAuth2Protocol::OAuth2Protocol_ResponseType_OTP,
+            OAuth2Protocol::OAuth2PasswordlessConnection => OAuth2Protocol::OAuth2PasswordlessConnectionInline,
+            OAuth2Protocol::OAuth2PasswordlessSend => OAuth2Protocol::OAuth2PasswordlessSendCode,
+            OAuth2Protocol::OAuth2PasswordlessEmail => "test@test.com",
+        ];
+
+        $response = $this->action("POST", "OAuth2\OAuth2ProviderController@auth",
+            $params,
+            [],
+            [],
+            [],
+            // Symfony interally prefixes headers with "HTTP", so
+            ["HTTP_Authorization" => " Basic " . base64_encode(self::$resource_server->getClient()->getClientId() . ':' . self::$resource_server->getClient()->getClientSecret())]
+        );
+
+        $this->assertResponseStatus(200);
+
+        $this->assertEquals('application/json;charset=UTF-8', $response->headers->get('Content-Type'));
+
+        $content = $response->getContent();
+
+        $otp_response = json_decode($content);
+
+        $this->assertTrue($otp_response->scope == $scope);
+
+        $otp = $otp_response->value;
+        // exchange
+        $params = [
+            'grant_type' => OAuth2Protocol::OAuth2Protocol_GrantType_Passwordless,
+            OAuth2Protocol::OAuth2PasswordlessConnection => OAuth2Protocol::OAuth2PasswordlessConnectionEmail,
+            OAuth2Protocol::OAuth2PasswordlessEmail =>"test@test.com",
+            OAuth2Protocol::OAuth2Protocol_ResponseType_OTP => $otp,
+            OAuth2Protocol::OAuth2Protocol_Scope => $scope
+        ];
+
+        $response = $this->action("POST", "OAuth2\OAuth2ProviderController@token",
+            $params,
+            [],
+            [],
+            [],
+            // Symfony interally prefixes headers with "HTTP", so
+            array("HTTP_Authorization" => " Basic " . base64_encode(self::$client->getClientId() . ':' . self::$client->getClientSecret())));
+
+        $this->assertResponseStatus(400);
+
+        $content = $response->getContent();
+
+        $response = json_decode($content);
+
+        $this->assertTrue($response->error === 'invalid_grant');
+    }
+
+    public function testCodeInlineFlowComplete() {
+
+        $scope = sprintf('%s profile email address %s',
+            OAuth2Protocol::OpenIdConnect_Scope,
+            OAuth2Protocol::OfflineAccess_Scope
+        );
+
+        $params = [
+            'client_id' => self::$client2->getClientId(),
+            'scope' => $scope,
+            OAuth2Protocol::OAuth2Protocol_Nonce => '123456',
+            OAuth2Protocol::OAuth2Protocol_ResponseType => OAuth2Protocol::OAuth2Protocol_ResponseType_OTP,
+            OAuth2Protocol::OAuth2PasswordlessConnection => OAuth2Protocol::OAuth2PasswordlessConnectionInline,
+            OAuth2Protocol::OAuth2PasswordlessSend => OAuth2Protocol::OAuth2PasswordlessSendCode,
+            OAuth2Protocol::OAuth2PasswordlessEmail => "test@test.com",
+        ];
+
+        $response = $this->action("POST", "OAuth2\OAuth2ProviderController@auth",
+            $params,
+            [],
+            [],
+            [],
+            // Symfony interally prefixes headers with "HTTP", so
+            ["HTTP_Authorization" => " Basic " . base64_encode(self::$resource_server->getClient()->getClientId() . ':' . self::$resource_server->getClient()->getClientSecret())]
+        );
+
+        $this->assertResponseStatus(200);
+
+        $this->assertEquals('application/json;charset=UTF-8', $response->headers->get('Content-Type'));
+
+        $content = $response->getContent();
+
+        $otp_response = json_decode($content);
+
+        $this->assertTrue($otp_response->scope == $scope);
+
+        $otp = $otp_response->value;
+
+        // OIDC flow
+
+        Session::put("openid.authorization.response", IAuthService::AuthorizationResponse_AllowOnce);
+        $code_verifier = "1qaz2wsx3edc4rfv5tgb6yhn7ujm8ik8ik9ol1qaz2wsx3edc4rfv5tgb6yhn~";
+        $encoded = base64_encode(hash('sha256', $code_verifier, true));
+
+        $codeChallenge = strtr(rtrim($encoded, '='), '+/', '-_');
+
+        $params = [
+            'client_id' => self::$client2->getClientId(),
+            'redirect_uri' => 'https://www.test.com/oauth2',
+            'response_type' => OAuth2Protocol::OAuth2Protocol_ResponseType_Code,
+            'response_mode' => 'fragment',
+            'scope' => $scope,
+            'state' => '123456',
+            'code_challenge' => $codeChallenge,
+            'code_challenge_method' => 'S256',
+            OAuth2Protocol::OAuth2Protocol_LoginHint => "test@test.com",
+            OAuth2Protocol::OAuth2Protocol_OTP_LoginHint => $otp,
+            OAuth2Protocol::OAuth2Protocol_Prompt => OAuth2Protocol::OAuth2Protocol_Prompt_Consent,
+        ];
+
+        $response = $this->action("GET", "OAuth2\OAuth2ProviderController@auth",
+            $params,
+            [],
+            [],
+            []);
+
+        $this->assertResponseStatus(302);
+        $url = $response->getTargetUrl();
+        // get auth code ...
+        $comps = @parse_url($url);
+        $fragment = $comps['fragment'];
+        $response = [];
+        parse_str($fragment, $response);
+
+        $this->assertTrue(isset($response['code']));
+        $this->assertTrue(isset($response['state']));
+        $this->assertTrue($response['state'] === '123456');
+
+        $params = [
+            'code' => $response['code'],
+            'redirect_uri' => 'https://www.test.com/oauth2',
+            'grant_type' => OAuth2Protocol::OAuth2Protocol_GrantType_AuthCode,
+            'code_verifier' => $code_verifier,
+            'client_id' => self::$client2->getClientId(),
+        ];
+
+        $response = $this->action
+        (
+            "POST",
+            "OAuth2\OAuth2ProviderController@token",
+            $params,
+            [],
+            [],
+            [],
+            []
+        );
+
+        $this->assertResponseStatus(200);
+        $this->assertEquals('application/json;charset=UTF-8', $response->headers->get('Content-Type'));
+        $content = $response->getContent();
+
+        $response = json_decode($content);
+        $access_token = $response->access_token;
+
+        $this->assertTrue(!empty($access_token));
+
+        $refresh_token = $response->refresh_token;
+
+        $this->assertTrue(!empty($refresh_token));
+
+        $params = [
+            'refresh_token' => $refresh_token,
+            'grant_type' => OAuth2Protocol::OAuth2Protocol_GrantType_RefreshToken,
+            'client_id' => self::$client2->getClientId()
+        ];
+
+        $response = $this->action("POST", "OAuth2\OAuth2ProviderController@token",
+            $params,
+            [],
+            [],
+            [],
+            []);
+
+        $this->assertResponseStatus(200);
+        $this->assertEquals('application/json;charset=UTF-8', $response->headers->get('Content-Type'));
+        $content = $response->getContent();
+
+        $response = json_decode($content);
+
+        //get new access token and new refresh token...
+        $new_access_token  = $response->access_token;
+        $new_refresh_token = $response->refresh_token;
+
+        $this->assertTrue(!empty($new_access_token));
+        $this->assertTrue(!empty($new_refresh_token));
+
     }
 
     public function testInvalidRedeemCodeEmailFlow() {

--- a/tests/OIDCProtocolTest.php
+++ b/tests/OIDCProtocolTest.php
@@ -3154,7 +3154,6 @@ final class OIDCProtocolTest extends OpenStackIDBaseTest
         $this->assertTrue(array_key_exists('id_token', $output));
         $this->assertTrue(!empty($output['id_token']));
 
-
         $params = array
         (
             'code' => $output['code'],


### PR DESCRIPTION
to use it later on a PKCE flow with otp_login_hint to provide an automatic auth UX to end user otp_login_hint should be used in conjuction with login_hint param ( user name ).

Signed-off-by: smarcet@gmail.com <smarcet@gmail.com>
Change-Id: Iccb51edd057d104e0e5075a646803f125e2533e0