### PR TITLE
fix: test environment setup for clean Docker installs

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,0 +1,84 @@
+# .env.testing.example
+# Copy this to .env.testing before running the test suite.
+# Pre-configured for the standard Docker Compose local setup.
+# Adjust DB/Redis credentials if you changed them from the defaults.
+
+APP_ENV=testing
+APP_DEBUG=true
+# Generate with: php artisan key:generate --show
+APP_KEY=
+APP_URL=http://localhost
+
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=idp_local
+DB_USERNAME=idp_user
+DB_PASSWORD=1qaz2wsx!
+DB_USE_SSL=false
+
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+REDIS_PASSWORD=1qaz2wsx!
+REDIS_DATABASES=16
+
+CACHE_DRIVER=redis
+SESSION_DRIVER=redis
+SESSION_COOKIE_DOMAIN=localhost
+SESSION_COOKIE_SECURE=false
+
+QUEUE_DRIVER=redis
+QUEUE_CONN=openstackid
+QUEUE_DATABASE=openstackid
+
+MAIL_DRIVER=log
+MAIL_FROM_EMAIL=noreply@localhost
+MAIL_FROM_NAME=OpenStackID
+
+CORS_ALLOWED_HEADERS="origin, content-type, accept, authorization, x-requested-with"
+CORS_ALLOWED_METHODS="GET, POST, OPTIONS, PUT, DELETE"
+CORS_USE_PRE_FLIGHT_CACHING=true
+CORS_MAX_AGE=3200
+
+CURL_TIMEOUT=60
+CURL_ALLOWS_REDIRECT=false
+CURL_VERIFY_SSL_CERT=false
+
+SSL_ENABLED=false
+DB_LOG_ENABLED=false
+ACCESS_TOKEN_CACHE_LIFETIME=300
+API_RESPONSE_CACHE_LIFETIME=600
+
+LOG_LEVEL=debug
+
+RECAPTCHA_PUBLIC_KEY=
+RECAPTCHA_PRIVATE_KEY=
+
+BANNING_ENABLE=true
+SUPPORT_EMAIL=test@localhost
+MAIL_SEND_WELCOME_EMAIL=0
+
+AUTH_ALLOWS_NATIVE_AUTH=1
+AUTH_ALLOWS_OTP=1
+AUTH_ALLOWS_NATIVE_AUTH_CONFIG=1
+OTP_DEFAULT_LIFETIME=600
+OTP_DEFAULT_LENGTH=6
+
+AUTH_PASSWORD_RESET_LIFETIME=1800
+AUTH_PASSWORD_SHAPE_PATTERN="^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-])"
+AUTH_PASSWORD_SHAPE_WARNING="Password must include at least one uppercase letter, one lowercase letter, one number, and one special character."
+
+OTEL_SERVICE_ENABLED=false
+OTEL_SDK_DISABLED=true
+
+L5_SWAGGER_CONST_HOST=http://localhost
+L5_SWAGGER_GENERATE_ALWAYS=false
+
+FACEBOOK_REDIRECT_URI=/auth/login/facebook/callback
+GOOGLE_REDIRECT_URI=/auth/login/google/callback
+APPLE_REDIRECT_URI=/auth/login/apple/callback
+LINKEDIN_REDIRECT_URI=/auth/login/linkedin/callback
+
+APP_NAME="Open Event"
+TENANT_NAME="the Open Event Platform"

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Homestead.yaml
 Homestead.json
 .env
 .env.*
+!.env.testing.example
 storage/*
 /public/assets/jquery-cookie/
 /public/assets/crypto-js/

--- a/LOCAL_DEVELOPMENT_HOWTO.md
+++ b/LOCAL_DEVELOPMENT_HOWTO.md
@@ -44,3 +44,30 @@ check containers health status
 ````bash
 docker inspect --format "{{json .State.Health }}" www-openstack-model-db-local | jq '.
 ````
+Running the Test Suite
+======================
+
+The test suite uses `APP_ENV=testing`, which causes Laravel to load `.env.testing`
+instead of `.env`. **You must create a `.env.testing` file before running tests** —
+this is a Laravel convention and is not obvious from the error output if it's missing.
+
+Copy the example file and adjust if needed:
+
+```bash
+cp .env.testing.example .env.testing
+```
+
+The example file is pre-configured for the standard Docker Compose setup (same
+credentials as `.env`). If you changed any DB or Redis credentials, update `.env.testing`
+to match.
+
+Then run the tests:
+
+```bash
+./run_tests.sh
+```
+
+**Note:** The test suite clears and re-seeds the relevant DB tables on every run, so
+you do not need to run `idp:fresh` before running tests. Also, `phpunit.xml` is
+configured with `stopOnFailure=true` — if you see fewer tests than expected, it means
+an earlier test failed and halted the suite.

--- a/database/seeds/TestSeeder.php
+++ b/database/seeds/TestSeeder.php
@@ -455,6 +455,7 @@ PPK;
         $this->seedApiScopes();
         $this->seedApiEndpointScopes();
         $this->seedApiScopeScopes();
+        $this->seedGroupScopes();
         $this->seedTestApiEndpoints();
         // clients
         $this->seedTestUsersAndClients();
@@ -738,6 +739,13 @@ PPK;
                 'name'            => 'api-scope',
                 'active'          =>  true,
                 'description'     => 'Api Scopes CRUD operations',
+                'resource_server' => $resource_server,
+                'logo'               => asset('/assets/img/apis/server.png')
+            ),
+            array(
+                'name'            => 'groups',
+                'active'          =>  true,
+                'description'     => 'Groups Info API',
                 'resource_server' => $resource_server,
                 'logo'               => asset('/assets/img/apis/server.png')
             ),
@@ -1162,7 +1170,37 @@ PPK;
         EntityManager::flush();
     }
 
-    private function seedTestApiEndpoints(){
+    private function seedGroupScopes(){
+        $api_repository = EntityManager::getRepository(Api::class);
+        $api = $api_repository->findOneBy(['name' => 'groups']);
+        if(is_null($api)) return;
+
+        $scope_payloads = [
+            array(
+                'name'               => \App\libs\OAuth2\IGroupScopes::ReadAll,
+                'short_description'  => 'Allows access to Groups info.',
+                'description'        => 'Allows access to Groups info.',
+                'api'                => $api,
+                'system'             => false,
+                'active'             => true,
+            ),
+            array(
+                'name'               => \App\libs\OAuth2\IGroupScopes::Write,
+                'short_description'  => 'Allows access to write Groups info.',
+                'description'        => 'Allows access to write Groups info.',
+                'api'                => $api,
+                'system'             => false,
+                'active'             => true,
+            ),
+        ];
+
+        foreach($scope_payloads as $payload) {
+            EntityManager::persist(ApiScopeFactory::build($payload));
+        }
+        EntityManager::flush();
+    }
+
+        private function seedTestApiEndpoints(){
 
         $current_realm  = Config::get('app.url');
 


### PR DESCRIPTION
## What

Two fixes that make the test suite work correctly in clean Docker environments (i.e. when someone clones the repo fresh and runs the tests for the first time).

### 1. Fix: seed `groups` API and scopes in `TestSeeder`

`OAuth2GroupApiTest` requests the `groups/read-all` and `groups/write` scopes during its OAuth2 flow. These scopes are created by a data migration (`Version20250731141145`), but `OpenStackIDBaseTestCase` wipes `oauth2_api_scope` before every test run and re-seeds from `TestSeeder` — which did not include these scopes.

In a clean environment where migrations are run before the tests, the migration is already recorded as applied, so it does not re-run during the test, and the scopes are never restored. Result: 400 on the token endpoint, test fails.

Fixed by adding the `groups` API and its two scopes to `TestSeeder` directly, following the same pattern used for other APIs.

### 2. Docs: add `.env.testing.example` and testing instructions

When PHPUnit runs, it sets `APP_ENV=testing` (via `phpunit.xml`), causing Laravel to load `.env.testing` instead of `.env`. This is not documented anywhere, and the missing file produces no clear error — it just silently falls back to `.env`, which is missing many vars the OAuth2 server depends on.

Added:
- `.env.testing.example` — pre-configured for the standard Docker Compose setup, ready to copy
- A "Running the Test Suite" section in `LOCAL_DEVELOPMENT_HOWTO.md` explaining the `.env.testing` requirement and the `stopOnFailure` behavior
- Updated `.gitignore` to allow `.env.testing.example` to be committed despite the `.env.*` rule

## Why

Both issues caused `OAuth2GroupApiTest::testGetAll` to fail (returning 400 instead of 200) in any clean Docker setup. The root causes were non-obvious and would affect any new contributor setting up the project for the first time.