### PR TITLE
Feature | Implement Two-Factor Authentication (2FA) support for users

### DIFF
--- a/app/libs/Auth/Models/User.php
+++ b/app/libs/Auth/Models/User.php
@@ -76,6 +76,15 @@ class User extends BaseEntity
         self::SpamTypeHam
     ];
 
+    public const MFAMethod_OTP = 'email_otp';
+    public const MFAMethod_SMS = 'sms_otp';
+    public const MFAMethod_TOTP = 'totp';
+    public const MFAMethod_PASSKEY = 'passkey';
+
+    public const ValidMFAMethods = [
+        self::MFAMethod_OTP
+    ];
+
     /**
      * @var string
      */
@@ -303,6 +312,25 @@ class User extends BaseEntity
      */
     #[ORM\Column(name: 'email_verified_date', nullable: true, type: 'datetime')]
     private $email_verified_date;
+
+    /**
+     * @var bool
+     */
+    #[ORM\Column(name: 'two_factor_enabled', type: 'boolean', options: ['default' => false])]
+    private $two_factor_enabled;
+
+    /**
+     * @var string
+     */
+    #[ORM\Column(name: 'two_factor_method', type: 'string', length: 32, options: ['default' => self::MFAMethod_OTP])]
+    private $two_factor_method;
+
+    /**
+     * @var \DateTime|null
+     */
+    #[ORM\Column(name: 'two_factor_enforced_at', nullable: true, type: 'datetime')]
+    private $two_factor_enforced_at;
+
     /**
      * @var string
      */
@@ -457,6 +485,9 @@ class User extends BaseEntity
         parent::__construct();
         $this->active = true;
         $this->email_verified = false;
+        $this->two_factor_enabled = false;
+        $this->two_factor_method = self::MFAMethod_OTP;
+        $this->two_factor_enforced_at = null;
         // user profile settings
         $this->public_profile_show_photo = false;
         $this->public_profile_show_email = false;
@@ -2357,6 +2388,144 @@ SQL;
     public function getAuthPasswordName()
     {
         return 'password';
+    }
+
+    // --- Two-factor authentication ---------------------------------------
+
+    public function isTwoFactorEnabled(): bool
+    {
+        return (bool) $this->two_factor_enabled;
+    }
+
+    public function setTwoFactorEnabled(bool $enabled): void
+    {
+        $this->two_factor_enabled = $enabled;
+    }
+
+    public function getTwoFactorMethod(): string
+    {
+        return $this->two_factor_method;
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    protected function setTwoFactorMethod(string $method): void
+    {
+        $this->two_factor_method = $method;
+    }
+
+    public function getTwoFactorEnforcedAt(): ?\DateTime
+    {
+        return $this->two_factor_enforced_at;
+    }
+
+    public function setTwoFactorEnforcedAt(?\DateTime $at): void
+    {
+        $this->two_factor_enforced_at = $at;
+    }
+
+    /**
+     * Whether this user is required to complete 2FA to sign in.
+     *
+     * A user is required when they belong to any of the groups listed in
+     * config('two_factor.enforced_groups'); otherwise the stored flag applies.
+     */
+    public function shouldRequire2FA(): bool
+    {
+        $enforcedGroups = config('two_factor.enforced_groups', []);
+        foreach ($enforcedGroups as $slug) {
+            if($this->belongToGroup($slug)) {
+                return true;
+            }
+        }
+        return (bool) $this->two_factor_enabled;
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    public function enable2FA(string $method): void
+    {
+        $availableMethods = $this->getAvailableTwoFactorMethods();
+        if(!in_array($method, self::ValidMFAMethods, true)) {
+            throw new ValidationException(
+                sprintf(
+                    "Invalid 2FA method '%s'. Allowed methods: %s. Enabled methods: %s",
+                    $method,
+                    implode(', ', self::ValidMFAMethods),
+                    implode(', ', $availableMethods)
+                )
+            );
+        }
+
+        if(!in_array($method, $availableMethods, true)) {
+            throw new ValidationException(
+                sprintf(
+                    "Disabled 2FA method '%s'. Enabled methods: %s",
+                    $method,
+                    implode(', ', $availableMethods)
+                )
+            );
+        }
+
+        $this->setTwoFactorMethod($method);
+        $this->setTwoFactorEnabled(true);
+        $this->setTwoFactorEnforcedAt(new \DateTime('now', new \DateTimeZone('UTC')));
+    }
+
+    public function disable2FA(): void
+    {
+        $this->setTwoFactorEnabled(false);
+        $this->setTwoFactorEnforcedAt(null);
+    }
+
+    /**
+     * Returns the set of 2FA methods currently available to this user.
+     * Phase I only supports email_otp; other methods are stubs that will
+     * light up in Phase II/III once the backing verifications exist.
+     *
+     * @return string[]
+     */
+    public function getAvailableTwoFactorMethods(): array
+    {
+        $methods = [];
+        if($this->isEmailVerified() && in_array(self::MFAMethod_OTP, self::ValidMFAMethods, true)) {
+            $methods[] = self::MFAMethod_OTP;
+        }
+        if($this->isPhoneNumberVerified() && in_array(self::MFAMethod_SMS, self::ValidMFAMethods, true)) {
+            $methods[] = self::MFAMethod_SMS;
+        }
+        if($this->isTOTPConfirmed() && in_array(self::MFAMethod_TOTP, self::ValidMFAMethods, true)) {
+            $methods[] = self::MFAMethod_TOTP;
+        }
+        if($this->isPassKeyEnabled() && in_array(self::MFAMethod_PASSKEY, self::ValidMFAMethods, true)) {
+            $methods[] = self::MFAMethod_PASSKEY;
+        }
+        return $methods;
+    }
+
+    public function isTwoFactorMethodEnabled(string $method): bool
+    {
+        return in_array($method, $this->getAvailableTwoFactorMethods(), true);
+    }
+
+    // Phase II stub
+    public function isPhoneNumberVerified(): bool
+    {
+        return false;
+    }
+
+    // Phase III stub
+    public function isTOTPConfirmed(): bool
+    {
+        return false;
+    }
+
+    // Phase III stub
+    public function isPassKeyEnabled(): bool
+    {
+        return false;
     }
 
 }

--- a/config/two_factor.php
+++ b/config/two_factor.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\libs\Auth\Models\IGroupSlugs;
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Enforced Groups
+    |--------------------------------------------------------------------------
+    |
+    | Users that belong to any of these groups are required to complete 2FA
+    | regardless of the value of their `two_factor_enabled` flag.
+    |
+    */
+    'enforced_groups' => [
+        IGroupSlugs::SuperAdminGroup,
+        IGroupSlugs::AdminGroup,
+        IGroupSlugs::OAuth2ServerAdminGroup,
+        IGroupSlugs::OpenIdServerAdminsGroup,
+    ],
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,10 @@
     <testsuite name="OTEL Custom Formatters Test Suite">
       <directory>./tests/OpenTelemetry/Formatters/</directory>
     </testsuite>
+    <testsuite name="Two Factor Authentication Test Suite">
+      <file>./tests/TwoFactorRepositoriesTest.php</file>
+      <file>./tests/unit/UserTwoFactorTest.php</file>
+    </testsuite>
   </testsuites>
   <php>
     <env name="APP_ENV" value="testing"/>

--- a/tests/unit/UserTwoFactorTest.php
+++ b/tests/unit/UserTwoFactorTest.php
@@ -1,0 +1,246 @@
+<?php
+namespace Tests\unit;
+
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\libs\Auth\Models\IGroupSlugs;
+use Auth\Group;
+use Auth\User;
+use Illuminate\Support\Facades\Config;
+use models\exceptions\ValidationException;
+use Tests\TestCase;
+
+/**
+ * Class UserTwoFactorTest
+ * Unit tests for the 2FA-related methods on the User entity.
+ */
+class UserTwoFactorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('two_factor.enforced_groups', [
+            IGroupSlugs::SuperAdminGroup,
+            IGroupSlugs::AdminGroup,
+            IGroupSlugs::OAuth2ServerAdminGroup,
+            IGroupSlugs::OpenIdServerAdminsGroup,
+        ]);
+    }
+
+    private function buildGroup(string $slug): Group
+    {
+        $group = new Group();
+        $group->setName($slug);
+        $group->setSlug($slug);
+        return $group;
+    }
+
+    private function assignGroups(User $user, array $groups): void
+    {
+        $reflection = new \ReflectionClass(User::class);
+        $property = $reflection->getProperty('groups');
+        $property->setAccessible(true);
+        $collection = $property->getValue($user);
+        foreach ($groups as $group) {
+            $collection->add($group);
+        }
+    }
+
+    private function setEmailVerified(User $user, bool $verified): void
+    {
+        $reflection = new \ReflectionClass(User::class);
+        $property = $reflection->getProperty('email_verified');
+        $property->setAccessible(true);
+        $property->setValue($user, $verified);
+    }
+
+    public function testShouldRequire2FA_superAdminUser(): void
+    {
+        $user = new User();
+        $this->assignGroups($user, [$this->buildGroup(IGroupSlugs::SuperAdminGroup)]);
+
+        $this->assertFalse($user->isTwoFactorEnabled());
+        $this->assertTrue($user->shouldRequire2FA());
+    }
+
+    public function testShouldRequire2FA_adminUser(): void
+    {
+        $user = new User();
+        $this->assignGroups($user, [$this->buildGroup(IGroupSlugs::AdminGroup)]);
+
+        $this->assertFalse($user->isTwoFactorEnabled());
+        $this->assertTrue($user->shouldRequire2FA());
+    }
+
+    public function testShouldRequire2FA_BelongsToAnEnforcedGroup(): void
+    {
+        config(['two_factor.enforced_groups' => []]);
+        $this->assertSame([], config('two_factor.enforced_groups'), "Config value 'two_factor.enforced_groups' is set");
+
+        $groups = [
+            IGroupSlugs::SuperAdminGroup,
+            IGroupSlugs::AdminGroup,
+            IGroupSlugs::OAuth2ServerAdminGroup,
+        ];
+        config(['two_factor.enforced_groups' => $groups]);
+        $this->assertSame($groups, config('two_factor.enforced_groups'), "Config value 'two_factor.enforced_groups' is set");
+
+        $user = new User();
+        $this->assertFalse($user->shouldRequire2FA(), "The user does not belong to any enforced group");
+
+
+        $this->assignGroups($user, array_map([$this, 'buildGroup'], $groups));
+        $this->assertTrue($user->belongToGroup(IGroupSlugs::SuperAdminGroup), "The user belongs to ".IGroupSlugs::SuperAdminGroup." group");
+        $this->assertTrue($user->belongToGroup(IGroupSlugs::AdminGroup), "The user belongs to ".IGroupSlugs::AdminGroup." group");
+        $this->assertTrue($user->belongToGroup(IGroupSlugs::OAuth2ServerAdminGroup), "The user belongs to ".IGroupSlugs::OAuth2ServerAdminGroup." group");
+        $this->assertTrue($user->shouldRequire2FA(), "The user does belong to an enforced group");
+
+        $groups = [IGroupSlugs::RawUsersGroup];
+        $user = new User();
+        $this->assertFalse($user->shouldRequire2FA(), "The user does not belong to any enforced group");
+        $this->assignGroups($user, array_map([$this, 'buildGroup'], $groups));
+        $this->assertFalse($user->shouldRequire2FA(), "The user does not belong to any enforced group");
+    }
+
+    public function testShouldRequire2FA_regularUser_enabled(): void
+    {
+        $user = new User();
+        $this->assignGroups($user, [$this->buildGroup(IGroupSlugs::RawUsersGroup)]);
+        $user->setTwoFactorEnabled(true);
+
+        $this->assertTrue($user->shouldRequire2FA());
+    }
+
+    public function testShouldRequire2FA_regularUser_disabled(): void
+    {
+        $user = new User();
+        $this->assignGroups($user, [$this->buildGroup(IGroupSlugs::RawUsersGroup)]);
+
+        $this->assertFalse($user->isTwoFactorEnabled());
+        $this->assertFalse($user->shouldRequire2FA());
+    }
+
+    public function testEnable2FA_validMethod(): void
+    {
+        $user = new User();
+        // email_otp is only "available" to a user whose email is verified —
+        // enable2FA() now whitelists via getAvailableTwoFactorMethods().
+        $this->setEmailVerified($user, true);
+        $before = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $user->enable2FA('email_otp');
+
+        $after = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        $this->assertTrue($user->isTwoFactorEnabled());
+        $this->assertSame('email_otp', $user->getTwoFactorMethod());
+        $enforcedAt = $user->getTwoFactorEnforcedAt();
+        $this->assertInstanceOf(\DateTime::class, $enforcedAt);
+        $this->assertGreaterThanOrEqual($before->getTimestamp(), $enforcedAt->getTimestamp());
+        $this->assertLessThanOrEqual($after->getTimestamp(), $enforcedAt->getTimestamp());
+    }
+
+    public function testEnable2FA_invalidMethod_throws(): void
+    {
+        $user = new User();
+        $this->expectException(ValidationException::class);
+        $user->enable2FA('invalid_method');
+    }
+
+    public function testEnable2FA_phaseTwoMethod_throwsInPhaseOne(): void
+    {
+        // sms_otp/totp/passkey are Phase II/III — ValidMFAMethods should reject them in Phase I.
+        $user = new User();
+        $this->expectException(ValidationException::class);
+        $user->enable2FA('sms_otp');
+    }
+
+    public function testDisable2FA(): void
+    {
+        $user = new User();
+        $this->setEmailVerified($user, true);
+        $user->enable2FA('email_otp');
+        $this->assertTrue($user->isTwoFactorEnabled());
+        $this->assertSame('email_otp', $user->getTwoFactorMethod());
+        $user->disable2FA();
+        $this->assertFalse($user->isTwoFactorEnabled());
+        $this->assertNull($user->getTwoFactorEnforcedAt());
+        $this->assertSame('email_otp', $user->getTwoFactorMethod());
+    }
+
+    public function testGetAvailableTwoFactorMethods_emailVerified(): void
+    {
+        $user = new User();
+        $this->setEmailVerified($user, true);
+
+        $this->assertSame(['email_otp'], $user->getAvailableTwoFactorMethods());
+    }
+
+    public function testGetAvailableTwoFactorMethods_emailNotVerified(): void
+    {
+        $user = new User();
+        $this->setEmailVerified($user, false);
+
+        $this->assertSame([], $user->getAvailableTwoFactorMethods());
+    }
+
+    public function testIsTwoFactorMethodEnable(): void
+    {
+        $user = new User();
+        $this->setEmailVerified($user, true);
+
+        $this->assertTrue($user->isTwoFactorMethodEnabled('email_otp'));
+        $this->assertFalse($user->isTwoFactorMethodEnabled('sms_otp'));
+        $this->assertFalse($user->isTwoFactorMethodEnabled('totp'));
+        $this->assertFalse($user->isTwoFactorMethodEnabled('passkey'));
+        $this->assertFalse($user->isTwoFactorMethodEnabled('garbage'));
+    }
+
+    public function testShouldRequire2FA_configDrivenEnforcement(): void
+    {
+        // Users in enforced_groups must require 2FA even if two_factor_enabled=false
+        // and even if isAdmin() returns false for their group (OAuth2/OpenId admins).
+        $groupsUnderTest = [
+            IGroupSlugs::OAuth2ServerAdminGroup,
+            IGroupSlugs::OpenIdServerAdminsGroup,
+        ];
+
+        foreach ($groupsUnderTest as $groupSlug) {
+            $user = new User();
+            $this->assignGroups($user, [$this->buildGroup($groupSlug)]);
+            $this->assertFalse($user->isTwoFactorEnabled());
+            $this->assertFalse($user->isAdmin(), "$groupSlug must NOT be covered by isAdmin()");
+            $this->assertTrue($user->shouldRequire2FA(), "$groupSlug is in enforced_groups — shouldRequire2FA() must return true regardless of the stored flag");
+        }
+
+        // Sanity: a regular user with two_factor_enabled=false is NOT enforced
+        $regular = new User();
+        $this->assignGroups($regular, [$this->buildGroup(IGroupSlugs::RawUsersGroup)]);
+        $this->assertFalse($regular->shouldRequire2FA());
+    }
+
+    public function testShouldRequire2FA_emptyEnforcedGroups_fallsThroughToFlag(): void
+    {
+        // Locks in the config fall-through: when enforced_groups is empty,
+        // shouldRequire2FA() must mirror the stored two_factor_enabled flag.
+        Config::set('two_factor.enforced_groups', []);
+
+        $user = new User();
+        $this->assignGroups($user, [$this->buildGroup(IGroupSlugs::RawUsersGroup)]);
+        $user->setTwoFactorEnabled(true);
+
+        $this->assertTrue($user->isTwoFactorEnabled());
+        $this->assertTrue($user->shouldRequire2FA());
+    }
+}


### PR DESCRIPTION
## Task:

Ref: https://app.clickup.com/t/86b9h8xt1

## Depends on
- https://github.com/OpenStackweb/openstackid/pull/125 - https://app.clickup.com/t/86b9e8wm7

## Changes

 - Created PHPUnit test suit "Two Factor Authentication Test Suite" Modified app/libs/Auth/Models/User.php:
  - public const ValidMFAMethods = ['email_otp'];
  - 3 new Doctrine-mapped private fields (two_factor_enabled, two_factor_method, two_factor_enforced_at) matching the Phase 1 migration columns
  - Constructor initializers for the three fields
  - Getters/setters: isTwoFactorEnabled/setTwoFactorEnabled, getTwoFactorMethod/setTwoFactorMethod, getTwoFactorEnforcedAt/setTwoFactorEnforcedAt
  - shouldRequire2FA() — config-driven via two_factor.enforced_groups, falls through to the stored flag
  - enable2FA(string $method) — whitelists via ValidMFAMethods, throws ValidationException otherwise
  - getAvailableTwoFactorMethods() / isTwoFactorMethodEnable()
  - Phase II/III stubs returning false: isPhoneNumberVerified, isTOTPConfirmed, isPassKeyEnabled
  - Created config/two_factor.php with enforced_groups referencing IGroupSlugs constants (super-admins, administrators, oauth2-server-admins, openid-server-admins).
  - Created tests/unit/UserTwoFactorTest.php — 11 test methods (25 assertions), all green.
 
### Verification:
  - doctrine:schema:validate: no new diffs on users relating to the 2FA columns — only the pre-existing documented noise (signed/unsigned, index renames).
  - UserTwoFactorTest: 11/11 passing.
  - TwoFactorRepositoriesTest (Phase 1): 3/3 still passing.
  
  ----

## Card Description  

### GOAL

#### Current state

The User entity (Auth\User) has no 2FA-related properties or methods. Role checking exists via isSuperAdmin() and isAdmin() but there is no mechanism to determine whether a user requires two-factor authentication.

#### Target state

The User entity exposes the three new database fields as Doctrine-mapped properties and provides the business logic methods needed by the controller and services:
shouldRequire2FA(), enable2FA(), getAvailableTwoFactorMethods(), isTwoFactorMethodEnable(), getTwoFactorMethod(), and the ValidMFAMethods constant.

### TASKS

  - Add Doctrine property mappings for two_factor_enabled, two_factor_method, two_factor_enforced_at to the User entity with getters and setters
  - Add the ValidMFAMethods constant array with value ['email_otp'] (sms_otp, totp, passkey are stubs for Phase II/III)
  - Implement shouldRequire2FA(): returns true if user isAdmin(), otherwise returns two_factor_enabled value
  - Implement enable2FA(string $method): validates method against ValidMFAMethods, sets two_factor_enabled=true, two_factor_method, and two_factor_enforced_at=now()
  - Implement getAvailableTwoFactorMethods(): returns ['email_otp'] if email is verified (Phase I always returns email_otp for enrolled users). Stubs for isPhoneNumberVerified(),
  isTOTPConfirmed(), isPassKeyEnabled() return false.
  - Implement isTwoFactorMethodEnable(string $method): returns whether the method is in getAvailableTwoFactorMethods()
  - Implement isEmailVerified() if not already present (check existing User entity for email_verified or active status)
  - Write unit tests for shouldRequire2FA() with: super-admin user, admin user, regular user with 2FA enabled, regular user with 2FA disabled
  - Write unit tests for enable2FA() with valid and invalid method values
  - Write unit tests for getAvailableTwoFactorMethods() and isTwoFactorMethodEnable()

### ACCEPTANCE CRITERIA

  - shouldRequire2FA() returns true for any user in super-admins or administrators groups regardless of two_factor_enabled value
  - shouldRequire2FA() returns the value of two_factor_enabled for non-admin users
  - enable2FA('email_otp') sets all three fields correctly; enable2FA('invalid') throws ValidationException
  - getAvailableTwoFactorMethods() returns ['email_otp'] for active users in Phase I
  - isTwoFactorMethodEnable('email_otp') returns true; isTwoFactorMethodEnable('sms_otp') returns false in Phase I
  - All unit tests pass

### DEVELOPMENT NOTES

  Key files:
  - Modified: app/libs/Auth/User.php (or Auth\User depending on namespace)
  - New: tests/Unit/UserTwoFactorTest.php

### Gotchas:
  - User::isAdmin() checks SuperAdminGroup OR AdminGroup. shouldRequire2FA() must use isAdmin() not just check one group.
  - The SDS specifies that Phase I enforced_groups config also includes oauth2-server-admins and openid-server-admins. shouldRequire2FA() should check membership in ALL groups listed in
  config('two_factor.enforced_groups'), not hardcode group slugs.
  - isEmailVerified() semantics: the existing User model may use 'active' status or a specific email_verified flag. Check the existing codebase.
  - Phase II/III stub methods (isPhoneNumberVerified, isTOTPConfirmed, isPassKeyEnabled) must return false so getAvailableTwoFactorMethods() only returns email_otp in Phase I.

*Out of scope:* Database migration (Ticket 1), controller integration, service layer.