### PR TITLE
fix(oauth2): allow HTTP origins and fix trailing-slash mismatch for l…

### DIFF
--- a/app/Models/OAuth2/Client.php
+++ b/app/Models/OAuth2/Client.php
@@ -809,9 +809,9 @@ class Client extends BaseEntity implements IClient
     {
         $originWithoutPort = URLUtils::canonicalUrl($origin, false);
         if(empty($originWithoutPort)) return false;
-        if(str_contains($this->allowed_origins, URLUtils::normalizeUrl($originWithoutPort) )) return true;
+        if(str_contains($this->allowed_origins, rtrim(URLUtils::normalizeUrl($originWithoutPort), '/') )) return true;
         $originWithPort = URLUtils::canonicalUrl($origin);
-        return str_contains($this->allowed_origins, URLUtils::normalizeUrl($originWithPort));
+        return str_contains($this->allowed_origins, rtrim(URLUtils::normalizeUrl($originWithPort), '/'));
     }
 
     public function getWebsite()
@@ -1097,7 +1097,7 @@ class Client extends BaseEntity implements IClient
         if ($parts == false) {
             return false;
         }
-        if($parts['scheme']!=='https')
+        if($parts['scheme']!=='https' && ServerConfigurationService::getConfigValue("SSL.Enable"))
             return false;
 
         $logout_without_port = $parts['scheme'].'://'.$parts['host'];

--- a/app/Services/Utils/ServerConfigurationService.php
+++ b/app/Services/Utils/ServerConfigurationService.php
@@ -159,7 +159,7 @@ class ServerConfigurationService
         $this->default_config_params["OAuth2SecurityPolicy.MaxInvalidRedeemAuthCodeAttempts"]    = Config::get('server.OAuth2SecurityPolicy_MaxInvalidRedeemAuthCodeAttempts', 10);
         $this->default_config_params["OAuth2SecurityPolicy.MaxInvalidClientCredentialsAttempts"] = Config::get('server.OAuth2SecurityPolicy_MaxInvalidClientCredentialsAttempts', 5);
         //ssl
-        $this->default_config_params["SSL.Enable"] = Config::get('server.SSL_Enable', true);
+        $this->default_config_params["SSL.Enable"] = Config::get('server.ssl_enabled', true);
     }
 
     public function getUserIdentityEndpointURL($identifier)
@@ -250,7 +250,7 @@ class ServerConfigurationService
         $request = request();
         if(!is_null($request))
         {
-            return 'https://'.$request->getHttpHost();
+            return $request->getSchemeAndHttpHost();
         }
         return Config::get('app.url');
     }

--- a/docker-compose/nginx/idp.conf
+++ b/docker-compose/nginx/idp.conf
@@ -12,6 +12,8 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_buffers 16 16k;
+        fastcgi_buffer_size 32k;
     }
     location / {
         try_files $uri $uri/ /index.php?$query_string;


### PR DESCRIPTION
…ocal dev

- Strip trailing slash from normalizeUrl() results in isOriginAllowed() so origins with/without trailing slash match registered values
- Conditionally skip HTTPS scheme enforcement when SSL.Enable is false, allowing HTTP clients in local dev
- Fix SSL.Enable config key lookup (server.SSL_Enable → server.ssl_enable) to match the key name defined in config/server.php
- Use getSchemeAndHttpHost() instead of hardcoded https:// prefix so the IDP base URL reflects the actual request scheme
- Add fastcgi_buffers directives to nginx config to prevent buffer overflow