### PR TITLE
Feature | Add Device Trust Service

### DIFF
--- a/app/Repositories/DoctrineUserTrustedDeviceRepository.php
+++ b/app/Repositories/DoctrineUserTrustedDeviceRepository.php
@@ -31,6 +31,30 @@ final class DoctrineUserTrustedDeviceRepository
         return Criteria::expr()->gt('expires_at', $now);
     }
 
+    public function getByUserAndDeviceIdentifier(User $user, string $deviceIdentifier): ?UserTrustedDevice
+    {
+        $criteria = Criteria::create()
+            ->where(Criteria::expr()->eq('user', $user))
+            ->andWhere(Criteria::expr()->eq('device_identifier', $deviceIdentifier))
+            ->setMaxResults(1);
+
+        $result = $this->matching($criteria)->first();
+        return $result instanceof UserTrustedDevice ? $result : null;
+    }
+
+    public function revokeAllForUser(User $user): void
+    {
+        $this->getEntityManager()
+            ->createQueryBuilder()
+            ->update($this->getBaseEntity(), 'd')
+            ->set('d.is_revoked', ':revoked')
+            ->where('d.user = :user')
+            ->setParameter('revoked', true)
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->execute();
+    }
+
     public function getActiveByUserAndIdentifier(User $user, string $deviceIdentifier): ?UserTrustedDevice
     {
         $criteria = Criteria::create()

--- a/app/Services/Auth/DeviceTrustService.php
+++ b/app/Services/Auth/DeviceTrustService.php
@@ -1,0 +1,85 @@
+<?php
+namespace App\Services\Auth;
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\libs\Auth\Models\UserTrustedDevice;
+use Auth\Repositories\IUserTrustedDeviceRepository;
+use Auth\User;
+use DateTime;
+use DateInterval;
+use DateTimeZone;
+
+/**
+ * Class DeviceTrustService
+ * @package App\Services\Auth
+ */
+final class DeviceTrustService implements IDeviceTrustService
+{
+    public function __construct(private readonly IUserTrustedDeviceRepository $repository)
+    {
+    }
+
+    public function generateDeviceIdentifier(string $token): string
+    {
+        return hash('sha256', $token);
+    }
+
+    public function trustDevice(User $user, string $userAgent, string $ipAddress): string
+    {
+        $rawToken = bin2hex(random_bytes(64));
+
+        $lifetimeDays = (int) config('two_factor.device_trust_lifetime_days', 30);
+        $now = new DateTime('now', new DateTimeZone('UTC'));
+        $expiresAt = clone $now;
+        $expiresAt->add(new DateInterval("P{$lifetimeDays}D"));
+
+        $device = new UserTrustedDevice();
+        $device->setUser($user);
+        $device->setDeviceIdentifier($this->generateDeviceIdentifier($rawToken));
+        $device->setDeviceName(substr($userAgent, 0, 255));
+        $device->setIpAddress($ipAddress);
+        $device->setUserAgent($userAgent);
+        $device->setTrustedAt($now);
+        $device->setExpiresAt($expiresAt);
+        $device->setLastSeenAt(clone $now);
+        $device->setIsRevoked(false);
+
+        $this->repository->add($device, true);
+
+        return $rawToken;
+    }
+
+    public function isDeviceTrusted(User $user, ?string $cookieToken): bool
+    {
+        if (empty($cookieToken)) {
+            return false;
+        }
+
+        $identifier = $this->generateDeviceIdentifier($cookieToken);
+        $device = $this->repository->getByUserAndDeviceIdentifier($user, $identifier);
+
+        if (!$device instanceof UserTrustedDevice || $device->isRevoked() || $device->isExpired()) {
+            return false;
+        }
+
+        $device->setLastSeenAt(new DateTime('now', new DateTimeZone('UTC')));
+        $this->repository->add($device, true);
+        return true;
+    }
+
+    public function removeTrustedDevices(User $user): void
+    {
+        $this->repository->revokeAllForUser($user);
+    }
+}

--- a/app/Services/Auth/IDeviceTrustService.php
+++ b/app/Services/Auth/IDeviceTrustService.php
@@ -1,0 +1,45 @@
+<?php namespace App\Services\Auth;
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Auth\User;
+
+/**
+ * Interface IDeviceTrustService
+ * @package App\Services\Auth
+ */
+interface IDeviceTrustService
+{
+    /**
+     * Checks whether the device identified by the given cookie token is trusted for the user.
+     * Updates last_seen_at on a valid match.
+     */
+    public function isDeviceTrusted(User $user, ?string $cookieToken): bool;
+
+    /**
+     * Marks the current device as trusted for the user.
+     * Returns the raw 128-character hex token to be stored in the cookie.
+     * The SHA-256 hash of the token (not the raw token) is persisted.
+     */
+    public function trustDevice(User $user, string $userAgent, string $ipAddress): string;
+
+    /**
+     * Revokes all trusted devices for the given user.
+     */
+    public function removeTrustedDevices(User $user): void;
+
+    /**
+     * Returns the SHA-256 hash of the given token used as the stored device identifier.
+     */
+    public function generateDeviceIdentifier(string $token): string;
+}

--- a/app/Services/Auth/TwoFactorServiceProvider.php
+++ b/app/Services/Auth/TwoFactorServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+namespace App\Services\Auth;
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Illuminate\Contracts\Support\DeferrableProvider;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Class TwoFactorServiceProvider
+ * @package App\Services\Auth
+ */
+final class TwoFactorServiceProvider extends ServiceProvider implements DeferrableProvider
+{
+    public function boot(): void
+    {
+    }
+
+    public function register(): void
+    {
+        $this->app->singleton(IDeviceTrustService::class, DeviceTrustService::class);
+    }
+
+    public function provides(): array
+    {
+        return [
+            IDeviceTrustService::class,
+        ];
+    }
+}

--- a/app/libs/Auth/Models/UserTrustedDevice.php
+++ b/app/libs/Auth/Models/UserTrustedDevice.php
@@ -24,7 +24,7 @@ use Doctrine\ORM\Mapping as ORM;
 class UserTrustedDevice extends BaseEntity
 {
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
-    #[ORM\ManyToOne(targetEntity: \Auth\User::class)]
+    #[ORM\ManyToOne(targetEntity: User::class)]
     private $user;
 
     #[ORM\Column(name: 'device_identifier', type: 'string', length: 255)]
@@ -54,6 +54,7 @@ class UserTrustedDevice extends BaseEntity
     public function __construct()
     {
         parent::__construct();
+        $this->last_seen_at = new \DateTime('now', new \DateTimeZone('UTC'));
         $this->is_revoked = false;
     }
 
@@ -136,5 +137,11 @@ class UserTrustedDevice extends BaseEntity
     public function setIsRevoked(bool $value): void
     {
         $this->is_revoked = $value;
+    }
+
+    public function isExpired(): bool
+    {
+        $now = new \DateTime('now', new \DateTimeZone('UTC'));
+        return $this->expires_at < $now;
     }
 }

--- a/app/libs/Auth/Repositories/IUserTrustedDeviceRepository.php
+++ b/app/libs/Auth/Repositories/IUserTrustedDeviceRepository.php
@@ -18,7 +18,17 @@ use models\utils\IBaseRepository;
 interface IUserTrustedDeviceRepository extends IBaseRepository
 {
     /**
-     * Look up an active (non-revoked) trusted device for a user by its hashed identifier.
+     * Look up a trusted device record by user and hashed identifier (no revoked/expiry filter).
+     */
+    public function getByUserAndDeviceIdentifier(User $user, string $deviceIdentifier): ?UserTrustedDevice;
+
+    /**
+     * Revoke all trusted devices for the given user (sets is_revoked = true).
+     */
+    public function revokeAllForUser(User $user): void;
+
+    /**
+     * Look up an active (non-revoked, non-expired) trusted device for a user by its hashed identifier.
      */
     public function getActiveByUserAndIdentifier(User $user, string $deviceIdentifier): ?UserTrustedDevice;
 

--- a/config/app.php
+++ b/config/app.php
@@ -152,6 +152,7 @@ return [
         Services\OpenId\OpenIdProvider::class,
         Auth\AuthenticationServiceProvider::class,
         Services\ServicesProvider::class,
+        App\Services\Auth\TwoFactorServiceProvider::class,
         Strategies\StrategyProvider::class,
         OAuth2\OAuth2ServiceProvider::class,
         OpenId\OpenIdServiceProvider::class,

--- a/config/two_factor.php
+++ b/config/two_factor.php
@@ -30,4 +30,12 @@ return [
         IGroupSlugs::OAuth2ServerAdminGroup,
         IGroupSlugs::OpenIdServerAdminsGroup,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Device Trust
+    |--------------------------------------------------------------------------
+    */
+    'device_trust_lifetime_days' => env('DEVICE_TRUST_LIFETIME_DAYS', 30),
+    'cookie_name' => env('DEVICE_TRUST_COOKIE_NAME', 'device_trust_token'),
 ];

--- a/tests/DeviceTrustServiceTest.php
+++ b/tests/DeviceTrustServiceTest.php
@@ -1,0 +1,290 @@
+<?php
+namespace Tests;
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\libs\Auth\Models\UserTrustedDevice;
+use App\Services\Auth\DeviceTrustService;
+use Auth\Repositories\IUserTrustedDeviceRepository;
+use Auth\User;
+use DateTime;
+use DateInterval;
+use DateTimeZone;
+use Mockery;
+
+/**
+ * Class DeviceTrustServiceTest
+ * @package Tests
+ */
+final class DeviceTrustServiceTest extends BrowserKitTestCase
+{
+    private DeviceTrustService $service;
+
+    /** @var \Mockery\MockInterface&IUserTrustedDeviceRepository */
+    private $repo;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = Mockery::mock(IUserTrustedDeviceRepository::class);
+        $this->service = new DeviceTrustService($this->repo);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        Mockery::close();
+    }
+
+    // -------------------------------------------------------------------------
+    // isDeviceTrusted
+    // -------------------------------------------------------------------------
+
+    public function testIsDeviceTrustedNullCookie(): void
+    {
+        $user = Mockery::mock(User::class);
+        $this->repo->shouldNotReceive('getByUserAndDeviceIdentifier');
+
+        $this->assertFalse($this->service->isDeviceTrusted($user, null));
+    }
+
+    public function testIsDeviceTrustedEmptyCookie(): void
+    {
+        $user = Mockery::mock(User::class);
+        $this->repo->shouldNotReceive('getByUserAndDeviceIdentifier');
+
+        $this->assertFalse($this->service->isDeviceTrusted($user, ''));
+    }
+
+    public function testIsDeviceTrustedWrongCookie(): void
+    {
+        $user = Mockery::mock(User::class);
+        $this->repo
+            ->shouldReceive('getByUserAndDeviceIdentifier')
+            ->once()
+            ->andReturn(null);
+
+        $this->assertFalse($this->service->isDeviceTrusted($user, 'unknowntoken'));
+    }
+
+    public function testIsDeviceTrustedRevokedDevice(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $device = $this->makeDevice(expired: false, revoked: true);
+
+        $this->repo
+            ->shouldReceive('getByUserAndDeviceIdentifier')
+            ->once()
+            ->andReturn($device);
+
+        $this->assertFalse($this->service->isDeviceTrusted($user, 'sometoken'));
+    }
+
+    public function testIsDeviceTrustedExpiredDevice(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $device = $this->makeDevice(expired: true, revoked: false);
+
+        $this->repo
+            ->shouldReceive('getByUserAndDeviceIdentifier')
+            ->once()
+            ->andReturn($device);
+
+        $this->assertFalse($this->service->isDeviceTrusted($user, 'sometoken'));
+    }
+
+    public function testIsDeviceTrustedValidDevice(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $device = $this->makeDevice(expired: false, revoked: false);
+
+        $this->repo
+            ->shouldReceive('getByUserAndDeviceIdentifier')
+            ->once()
+            ->andReturn($device);
+        $this->repo->shouldReceive('add')->once();
+
+        $this->assertTrue($this->service->isDeviceTrusted($user, 'sometoken'));
+    }
+
+    public function testIsDeviceTrustedUpdatesLastSeenAt(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $device = $this->makeDevice(expired: false, revoked: false);
+        // set last_seen_at to a known old value so the update is detectable
+        $oldDate = new DateTime('2000-01-01', new DateTimeZone('UTC'));
+        $device->setLastSeenAt($oldDate);
+
+        $this->repo
+            ->shouldReceive('getByUserAndDeviceIdentifier')
+            ->once()
+            ->andReturn($device);
+        $this->repo->shouldReceive('add')->once();
+
+        $this->service->isDeviceTrusted($user, 'sometoken');
+
+        $this->assertNotNull($device);
+        $this->assertGreaterThan($oldDate, $device->getLastSeenAt());
+    }
+
+    // -------------------------------------------------------------------------
+    // trustDevice
+    // -------------------------------------------------------------------------
+
+    public function testTrustDeviceReturnsToken(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $this->repo->shouldReceive('add')->once();
+
+        $token = $this->service->trustDevice($user, 'Mozilla/5.0', '127.0.0.1');
+
+        $this->assertSame(128, strlen($token));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{128}$/', $token);
+    }
+
+    public function testTrustDeviceStoresHash(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        /** @var UserTrustedDevice|null $persistedDevice */
+        $persistedDevice = null;
+
+        $this->repo
+            ->shouldReceive('add')
+            ->once()
+            ->withArgs(function ($device) use (&$persistedDevice) {
+                $persistedDevice = $device;
+                return true;
+            });
+
+        $rawToken = $this->service->trustDevice($user, 'Mozilla/5.0', '127.0.0.1');
+
+        $this->assertNotNull($persistedDevice);
+        $this->assertSame(hash('sha256', $rawToken), $persistedDevice->getDeviceIdentifier());
+    }
+
+    public function testTrustDeviceRawTokenNotStored(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        /** @var UserTrustedDevice|null $persistedDevice */
+        $persistedDevice = null;
+
+        $this->repo
+            ->shouldReceive('add')
+            ->once()
+            ->withArgs(function ($device) use (&$persistedDevice) {
+                $persistedDevice = $device;
+                return true;
+            });
+
+        $rawToken = $this->service->trustDevice($user, 'Mozilla/5.0', '127.0.0.1');
+
+        $this->assertNotNull($persistedDevice);
+        $this->assertNotSame($rawToken, $persistedDevice->getDeviceIdentifier());
+    }
+
+    public function testTrustDeviceCreatesExactlyOneRecord(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $this->repo->shouldReceive('add')->once();
+
+        $this->service->trustDevice($user, 'Mozilla/5.0', '127.0.0.1');
+    }
+
+    public function testTrustDeviceSetsExpiresAtFromConfig(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        /** @var UserTrustedDevice|null $persistedDevice */
+        $persistedDevice = null;
+
+        $this->repo
+            ->shouldReceive('add')
+            ->once()
+            ->withArgs(function ($device) use (&$persistedDevice) {
+                $persistedDevice = $device;
+                return true;
+            });
+
+        $this->service->trustDevice($user, 'Mozilla/5.0', '127.0.0.1');
+
+        $this->assertNotNull($persistedDevice);
+
+        $lifetimeDays = (int) config('two_factor.device_trust_lifetime_days', 30);
+        $diff = $persistedDevice->getTrustedAt()->diff($persistedDevice->getExpiresAt());
+        $this->assertSame($lifetimeDays, $diff->days);
+    }
+
+    // -------------------------------------------------------------------------
+    // removeTrustedDevices
+    // -------------------------------------------------------------------------
+
+    public function testRemoveTrustedDevicesRevokesAll(): void
+    {
+        $user = Mockery::mock(User::class);
+
+        $this->repo
+            ->shouldReceive('revokeAllForUser')
+            ->once()
+            ->with($user);
+
+        $this->service->removeTrustedDevices($user);
+    }
+
+    // -------------------------------------------------------------------------
+    // generateDeviceIdentifier
+    // -------------------------------------------------------------------------
+
+    public function testGenerateDeviceIdentifierReturnsSha256(): void
+    {
+        $token = 'test_token_value';
+        $expected = hash('sha256', $token);
+
+        $this->assertSame($expected, $this->service->generateDeviceIdentifier($token));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function makeDevice(bool $expired, bool $revoked): UserTrustedDevice
+    {
+        $device = new UserTrustedDevice();
+
+        $now = new DateTime('now', new DateTimeZone('UTC'));
+
+        if ($expired) {
+            $expiresAt = clone $now;
+            $expiresAt->sub(new DateInterval('P1D')); // 1 day in the past
+        } else {
+            $expiresAt = clone $now;
+            $expiresAt->add(new DateInterval('P30D')); // 30 days in the future
+        }
+
+        $device->setExpiresAt($expiresAt);
+        $device->setIsRevoked($revoked);
+        $device->setDeviceIdentifier($this->service->generateDeviceIdentifier('sometoken'));
+        $device->setIpAddress('127.0.0.1');
+        $device->setTrustedAt($now);
+        $device->setLastSeenAt(clone $now);
+
+        return $device;
+    }
+}


### PR DESCRIPTION
## Task:

Ref: https://app.clickup.com/t/86ba0nah4

## Blocked by:

PR: [Feature | MFA Challenge Strategy Pattern (Interface, Abstract, Factory, EmailOTP) #129](#129)

## Changes:

### New service layer (`app/Services/Auth/`)

  - **`IDeviceTrustService.php`** — Interface defining the contract: `trustDevice`, `isDeviceTrusted`, `removeTrustedDevices`, `generateDeviceIdentifier`.
  - **`DeviceTrustService.php`** — Implementation:
    - `trustDevice`: generates a 128-char random hex token, hashes it with SHA-256, persists a `UserTrustedDevice` record with configurable expiry (default 30 days), returns the raw token
  for cookie storage.
    - `isDeviceTrusted`: hashes the cookie token, looks up the record, returns `false` if not found / revoked / expired; updates `last_seen_at` on a valid hit.
    - `removeTrustedDevices`: bulk-revokes all devices for a user (sets `is_revoked = true`).
  - **`TwoFactorServiceProvider.php`** — Deferred service provider that binds `IDeviceTrustService → DeviceTrustService` as a singleton; registered in `config/app.php`.

### Repository changes (`IUserTrustedDeviceRepository` / `DoctrineUserTrustedDeviceRepository`)

  Two new methods added:

  - `getByUserAndDeviceIdentifier` — looks up a device by user + hashed identifier with no revoked/expiry filter (used by the service to check all states).
  - `revokeAllForUser` — bulk DQL `UPDATE` setting `is_revoked = true` for all devices belonging to a user.

### Entity updates (`UserTrustedDevice`)

  - Constructor now initializes `last_seen_at` to `now()`.
  - Added `isExpired()` helper (compares `expires_at` against now).
  - Fixed `targetEntity` reference from FQCN string to `User::class`.

### Config

  - **`config/two_factor.php`** — Added `device_trust_lifetime_days` (default `30`) and `cookie_name` (default `'device_trust_token'`) settings, driven by env vars.

### Tests (`tests/DeviceTrustServiceTest.php`)

  264-line unit test suite using Mockery covering:

  - `isDeviceTrusted`: null/empty cookie, unknown token, revoked device, expired device, valid device, `last_seen_at` update.
  - `trustDevice`: returns 128-char hex token, stores SHA-256 hash (not raw token), persists exactly one record.
  - `removeTrustedDevices`: delegates to `revokeAllForUser`.
  - `generateDeviceIdentifier`: SHA-256 correctness.

----

## Requested GOAL
### Current state

No device trust mechanism exists. Users would need to complete 2FA on every single login, even from the same browser and device they used yesterday.

### Target state

`IDeviceTrustService` and its implementation allow the system to remember trusted devices via a secure cookie mechanism. A SHA-256 hash of a cryptographically random token is stored
in the user_trusted_devices table with a configurable TTL (default 30 days). The raw token is stored in a long-lived HttpOnly cookie , On subsequent logins, the cookie token is hashed and compared against stored records to bypass 2FA.

### TASKS

  - Create `IDeviceTrustService` interface with methods: `isDeviceTrusted(User, ?string cookieToken): bool`, `trustDevice(User, string userAgent, string ipAddress): string` (returns raw cookie token), `removeTrustedDevices(User): void`, `generateDeviceIdentifier(string token): string` (returns SHA-256 hash)
  - Implement `DeviceTrustService`: `isDeviceTrusted()` hashes the cookie token via `generateDeviceIdentifier()`, queries `IUserTrustedDeviceRepository` for a matching non-revoked, non-expired record for the user, updates `last_seen_at` on match.
  - `trustDevice()` generates a 64-byte random token via `bin2hex(random_bytes(32))`, stores SHA-256 hash in user_trusted_devices with TTL from config, extracts User-Agent for `device_name`, returns raw token.
  - `removeTrustedDevices()` revokes all devices for the user (sets `is_revoked=true`).
  - Implement `IUserTrustedDeviceRepository::getByUserAndDeviceIdentifier()` query method
  - Register `IDeviceTrustService` in `TwoFactorServiceProvider`
  - Write unit tests for `isDeviceTrusted()` with: valid trusted device, expired device, revoked device, no cookie, wrong cookie
  - Write unit tests for `trustDevice()`: verify token generation, hash storage, and record creation
  - Write unit tests for `removeTrustedDevices()`: verify all devices for user are revoked
- `DeviceTrustService` must depend on `IUserTrustedDeviceRepository`, not `EntityManager` directly.
- `trustDevice()` must instantiate a `UserTrustedDevice` entity, associate it with the `User`, set `device_identifier`, `device_name`, `ip_address`, `user_agent`, `trusted_at`, `expires_at`, `last_seen_at`, `is_revoked=false`, then persist it through the repository.
- `isDeviceTrusted()` must call `IUserTrustedDeviceRepository::getByUserAndDeviceIdentifier($user, $deviceIdentifier)` and only return true for a non-revoked, non-expired record.
- On successful match, `isDeviceTrusted()` must update `last_seen_at` and persist the change.
- `removeTrustedDevices()` must call a repository method that revokes all trusted devices for the user.

### ACCEPTANCE CRITERIA

- `trustDevice()` returns a 128-character hex string (64 bytes as hex)
- The stored `device_identifier` is a SHA-256 hash of the returned token (not the raw token itself)
- `isDeviceTrusted()` returns true when a matching non-revoked, non-expired record exists
- `isDeviceTrusted()` returns `false` for expired records (`expires_at < now`)
- `isDeviceTrusted()` returns `false` for revoked records (`is_revoked = true`)
- `isDeviceTrusted()` returns `false` when cookieToken is null or empty
- `isDeviceTrusted()` updates `last_seen_at` on a valid match
- `removeTrustedDevices()` sets is_revoked=true on all records for the user
- DeviceTrustService does not query Doctrine directly; all `UserTrustedDevice` access goes through IUserTrustedDeviceRepository.
- `trustDevice()` creates exactly one `UserTrustedDevice` record per call.
- The raw cookie token is returned to the caller but is never stored in `UserTrustedDevice`.
- `UserTrustedDevice::device_identifier` stores hash('sha256', $rawToken).
- `isDeviceTrusted()` updates `UserTrustedDevice::last_seen_at` when a valid device is found.
- Device trust TTL defaults to 30 days, configurable via `config('two_factor.device_trust_lifetime_days')`
- cookie name is configuravle via a `config('two_factor.cookie_name')`
- All unit tests pass