### PR TITLE
Feature | Two-Factor Audit Service

### DIFF
--- a/app/Services/Auth/ITwoFactorAuditService.php
+++ b/app/Services/Auth/ITwoFactorAuditService.php
@@ -1,0 +1,35 @@
+<?php namespace App\Services\Auth;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Auth\User;
+
+/**
+ * Interface ITwoFactorAuditService
+ * @package App\Services\Auth
+ */
+interface ITwoFactorAuditService
+{
+    /**
+     * Persist a TwoFactorAuditLog record and emit corresponding OTLP attributes.
+     *
+     * @param User        $user      The user the event relates to.
+     * @param string      $eventType One of the TwoFactorAuditLog::Event* constants.
+     * @param string      $method    One of the TwoFactorAuditLog::Method* constants.
+     * @param string      $ipAddress Client IP address (IPv4 or IPv6).
+     * @param array|null  $metadata  Optional structured context; stored as JSON.
+     *
+     * @throws \InvalidArgumentException if $eventType or $method is not in the allowed set.
+     */
+    public function log(User $user, string $eventType, string $method, string $ipAddress, ?array $metadata = null): void;
+}

--- a/app/Services/Auth/TwoFactorAuditService.php
+++ b/app/Services/Auth/TwoFactorAuditService.php
@@ -1,0 +1,80 @@
+<?php
+namespace App\Services\Auth;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Jobs\EmitAuditLogJob;
+use App\libs\Auth\Models\TwoFactorAuditLog;
+use Auth\Repositories\ITwoFactorAuditLogRepository;
+use Auth\User;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Class TwoFactorAuditService
+ * @package App\Services\Auth
+ */
+final class TwoFactorAuditService implements ITwoFactorAuditService
+{
+    public function __construct(
+        private readonly ITwoFactorAuditLogRepository $repository
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function log(User $user, string $eventType, string $method, string $ipAddress, ?array $metadata = null): void
+    {
+        Log::debug('TwoFactorAuditService::log', [
+            'user_id' => $user->getId(),
+            'event_type' => $eventType,
+            'method' => $method,
+            'ip_address' => $ipAddress,
+        ]);
+
+        $auditLog = new TwoFactorAuditLog();
+        $auditLog->setUser($user);
+        $auditLog->setEventType($eventType);   // throws InvalidArgumentException on unknown type
+        $auditLog->setMethod($method);          // throws InvalidArgumentException on unknown method
+        $auditLog->setIpAddress($ipAddress);
+        // user_agent is captured from the current HTTP request context; falls back to empty
+        // string in CLI / queue contexts. A future signature change may accept $userAgent
+        // explicitly if project conventions require it (see ticket CU-86ba2z5gz).
+        $auditLog->setUserAgent(request()?->userAgent() ?? '');
+        $auditLog->setMetadata($metadata);
+
+        $this->repository->add($auditLog, true);
+
+        if (config('opentelemetry.enabled', false)) {
+            EmitAuditLogJob::dispatch('two_factor.audit', [
+                'two_factor.event_type' => $eventType,
+                'two_factor.method' => $method,
+                'two_factor.user_id' => $user->getId(),
+                'two_factor.ip_address' => $ipAddress,
+                'two_factor.success' => $this->resolveSuccess($eventType),
+                'two_factor.device_trusted' => $eventType === TwoFactorAuditLog::EventDeviceTrusted,
+                'elasticsearch.index' => config('opentelemetry.logs.elasticsearch_index', 'logs-audit'),
+            ]);
+        }
+    }
+
+    /**
+     * Derive whether the 2FA event represents a successful outcome.
+     * Only challenge_failed is treated as a failure; all other event types
+     * represent informational or successful operations.
+     */
+    private function resolveSuccess(string $eventType): bool
+    {
+        return $eventType !== TwoFactorAuditLog::EventChallengeFailed;
+    }
+}

--- a/app/Services/Auth/TwoFactorServiceProvider.php
+++ b/app/Services/Auth/TwoFactorServiceProvider.php
@@ -30,12 +30,14 @@ final class TwoFactorServiceProvider extends ServiceProvider implements Deferrab
     public function register(): void
     {
         $this->app->singleton(IDeviceTrustService::class, DeviceTrustService::class);
+        $this->app->singleton(ITwoFactorAuditService::class, TwoFactorAuditService::class);
     }
 
     public function provides(): array
     {
         return [
             IDeviceTrustService::class,
+            ITwoFactorAuditService::class,
         ];
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,6 +28,7 @@
       <file>./tests/Unit/MFA/AbstractMFAChallengeStrategyTest.php</file>
       <file>./tests/Unit/MFA/EmailOTPMFAChallengeStrategyTest.php</file>
       <file>./tests/Unit/MFA/MFAChallengeStrategyFactoryTest.php</file>
+      <file>./tests/Unit/TwoFactorAuditServiceTest.php</file>
     </testsuite>
   </testsuites>
   <php>

--- a/tests/Unit/TwoFactorAuditServiceTest.php
+++ b/tests/Unit/TwoFactorAuditServiceTest.php
@@ -1,0 +1,227 @@
+<?php
+namespace Tests\Unit;
+/**
+ * Copyright 2026 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Jobs\EmitAuditLogJob;
+use App\libs\Auth\Models\TwoFactorAuditLog;
+use App\Services\Auth\TwoFactorAuditService;
+use Auth\Repositories\ITwoFactorAuditLogRepository;
+use Auth\User;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * Class TwoFactorAuditServiceTest
+ * @package Tests\Unit
+ */
+final class TwoFactorAuditServiceTest extends TestCase
+{
+    /** @var TwoFactorAuditService */
+    private TwoFactorAuditService $service;
+
+    /** @var \Mockery\MockInterface&ITwoFactorAuditLogRepository */
+    private $repository;
+
+    /** @var \Mockery\MockInterface&User */
+    private $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Queue::fake();
+
+        $this->repository = Mockery::mock(ITwoFactorAuditLogRepository::class);
+        $this->service = new TwoFactorAuditService($this->repository);
+
+        $this->user = Mockery::mock(User::class);
+        $this->user->shouldReceive('getId')->andReturn(42);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // log() persists TwoFactorAuditLog with correct fields
+    // -------------------------------------------------------------------------
+
+    public function testLogPersistsTwoFactorAuditLogWithCorrectFields(): void
+    {
+        /** @var TwoFactorAuditLog|null $persisted */
+        $persisted = null;
+
+        $this->repository
+            ->shouldReceive('add')
+            ->once()
+            ->withArgs(function (TwoFactorAuditLog $log, bool $sync) use (&$persisted) {
+                $persisted = $log;
+                return $sync === true;
+            });
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeSucceeded,
+            TwoFactorAuditLog::MethodEmailOtp,
+            '127.0.0.1',
+            ['attempt' => 1]
+        );
+
+        $this->assertNotNull($persisted);
+        $this->assertSame($this->user, $persisted->getUser());
+        $this->assertSame(TwoFactorAuditLog::EventChallengeSucceeded, $persisted->getEventType());
+        $this->assertSame(TwoFactorAuditLog::MethodEmailOtp, $persisted->getMethod());
+        $this->assertSame('127.0.0.1', $persisted->getIpAddress());
+        $this->assertSame(['attempt' => 1], $persisted->getMetadata());
+    }
+
+    // -------------------------------------------------------------------------
+    // log() emits OTLP attributes
+    // -------------------------------------------------------------------------
+
+    public function testLogEmitsOtlpAttributes(): void
+    {
+        Config::set('opentelemetry.enabled', true);
+
+        $this->repository->shouldReceive('add')->once();
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeSucceeded,
+            TwoFactorAuditLog::MethodEmailOtp,
+            '10.0.0.1'
+        );
+
+        Queue::assertPushed(EmitAuditLogJob::class, function (EmitAuditLogJob $job) {
+            return $job->logMessage === 'two_factor.audit'
+                && $job->auditData['two_factor.event_type'] === TwoFactorAuditLog::EventChallengeSucceeded
+                && $job->auditData['two_factor.method'] === TwoFactorAuditLog::MethodEmailOtp
+                && $job->auditData['two_factor.user_id'] === 42
+                && $job->auditData['two_factor.ip_address'] === '10.0.0.1'
+                && $job->auditData['two_factor.success'] === true
+                && $job->auditData['two_factor.device_trusted'] === false;
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // log() emits two_factor.success = false for challenge_failed
+    // -------------------------------------------------------------------------
+
+    public function testLogEmitsSuccessFalseForChallengeFailed(): void
+    {
+        Config::set('opentelemetry.enabled', true);
+
+        $this->repository->shouldReceive('add')->once();
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeFailed,
+            TwoFactorAuditLog::MethodEmailOtp,
+            '10.0.0.1'
+        );
+
+        Queue::assertPushed(EmitAuditLogJob::class, function (EmitAuditLogJob $job) {
+            return $job->auditData['two_factor.event_type'] === TwoFactorAuditLog::EventChallengeFailed
+                && $job->auditData['two_factor.success'] === false;
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // log() does NOT dispatch job when OTLP is disabled (default)
+    // -------------------------------------------------------------------------
+
+    public function testLogDoesNotDispatchJobWhenOtlpDisabled(): void
+    {
+        Config::set('opentelemetry.enabled', false);
+
+        $this->repository->shouldReceive('add')->once();
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeSucceeded,
+            TwoFactorAuditLog::MethodEmailOtp,
+            '127.0.0.1'
+        );
+
+        Queue::assertNotPushed(EmitAuditLogJob::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // log() accepts null metadata
+    // -------------------------------------------------------------------------
+
+    public function testLogAcceptsNullMetadata(): void
+    {
+        /** @var TwoFactorAuditLog|null $persisted */
+        $persisted = null;
+
+        $this->repository
+            ->shouldReceive('add')
+            ->once()
+            ->withArgs(function (TwoFactorAuditLog $log) use (&$persisted) {
+                $persisted = $log;
+                return true;
+            });
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeIssued,
+            TwoFactorAuditLog::MethodTotp,
+            '192.168.1.1',
+            null
+        );
+
+        $this->assertNotNull($persisted);
+        $this->assertNull($persisted->getMetadata());
+    }
+
+    // -------------------------------------------------------------------------
+    // invalid event type throws InvalidArgumentException
+    // -------------------------------------------------------------------------
+
+    public function testInvalidEventTypeThrowsInvalidArgumentException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->shouldNotReceive('add');
+
+        $this->service->log(
+            $this->user,
+            'not_a_valid_event',
+            TwoFactorAuditLog::MethodEmailOtp,
+            '127.0.0.1'
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // invalid method throws InvalidArgumentException
+    // -------------------------------------------------------------------------
+
+    public function testInvalidMethodThrowsInvalidArgumentException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repository->shouldNotReceive('add');
+
+        $this->service->log(
+            $this->user,
+            TwoFactorAuditLog::EventChallengeIssued,
+            'not_a_valid_method',
+            '127.0.0.1'
+        );
+    }
+}


### PR DESCRIPTION
## Task

ref.: https://app.clickup.com/t/86ba2z5gz

## Changes:

  #### New Files

  | File | Purpose |
  |---|---|
  | `app/Services/Auth/ITwoFactorAuditService.php` | Interface declaring the `log()` contract |
  | `app/Services/Auth/TwoFactorAuditService.php` | Concrete implementation |
  | `tests/Unit/TwoFactorAuditServiceTest.php` | Unit test suite (6 cases) |

  #### Modified Files

  | File | Change |
  |---|---|
  | `app/Services/Auth/TwoFactorServiceProvider.php` | Registers `ITwoFactorAuditService → TwoFactorAuditService` as a singleton |
  | `phpunit.xml` | Adds the `Two Factor Authentication Test Suite` |

  ---

  ### Design Decisions

  - **Single method interface** — `ITwoFactorAuditService::log(User, eventType, method, ipAddress, ?metadata)` keeps the contract minimal and explicit. Validation of allowed event types
  and methods is delegated to `TwoFactorAuditLog` entity setters (throws `InvalidArgumentException` on unknown values).

  - **Sync persistence** — the audit log is flushed immediately (`$repository->add($log, true)`) to guarantee the record lands before the request finishes, regardless of OTEL availability.

  - **OTEL is optional** — `EmitAuditLogJob` is only dispatched when `opentelemetry.enabled` is `true`, keeping the happy path free of queue overhead in environments where telemetry is
  disabled.

  - **`two_factor.success` derivation** — only `EventChallengeFailed` maps to `false`; every other event type (issued, succeeded, device-trusted, etc.) is treated as a
  successful/informational outcome.

  ---

  ### OTLP Attributes Emitted

  When OpenTelemetry is enabled the following structured attributes are sent under
  the `two_factor.audit` message:

  | Attribute | Type | Description |
  |---|---|---|
  | `two_factor.event_type` | `string` | One of the `TwoFactorAuditLog::Event*` constants |
  | `two_factor.method` | `string` | One of the `TwoFactorAuditLog::Method*` constants |
  | `two_factor.user_id` | `int` | The authenticated user ID |
  | `two_factor.ip_address` | `string` | Client IPv4 / IPv6 address |
  | `two_factor.success` | `bool` | `false` only for `challenge_failed` |
  | `two_factor.device_trusted` | `bool` | `true` only for `device_trusted` events |
  | `elasticsearch.index` | `string` | Target index (`logs-audit` by default) |

  ---

  ### Tests

  tests/Unit/TwoFactorAuditServiceTest.php

  | Test | What it covers |
  |---|---|
  | `testLogPersistsTwoFactorAuditLogWithCorrectFields` | All entity fields are set before repository flush |
  | `testLogEmitsOtlpAttributes` | Correct OTLP payload is dispatched when OTEL is enabled |
  | `testLogEmitsSuccessFalseForChallengeFailed` | `two_factor.success = false` for failed challenges |
  | `testLogAcceptsNullMetadata` | Nullable metadata does not break persistence |
  | `testInvalidEventTypeThrowsInvalidArgumentException` | Guard against unknown event types |
  | `testInvalidMethodThrowsInvalidArgumentException` | Guard against unknown 2FA methods |

----

## Requested GOAL

### Current state
No 2FA-specific audit service exists. MFA events would be inconsistently logged or only visible through generic application logs.

### Target state

TwoFactorAuditService provides a centralized audit primitive that persists TwoFactorAuditLog records and emits OTLP audit attributes through the existing fntech-audit pipeline.

  This ticket provides audit infrastructure only. It does not wire audit calls into controller methods, strategies, or device-trust flows. That wiring belongs to Ticket 9/10, where the real MFA flow exists.

### TASKS

  - Create ITwoFactorAuditService interface with:
    - log(User $user, string $eventType, string $method, string $ipAddress, ?array $metadata = null): void
  - Implement TwoFactorAuditService.
  - Validate eventType against:
    - challenge_issued
    - challenge_succeeded
    - challenge_failed
    - enrollment_changed
    - device_trusted
    - device_revoked
    - recovery_used
    - settings_changed
  - Validate method against:
    - email_otp
    - sms_otp
    - totp
    - passkey
    - recovery
  - Create and persist TwoFactorAuditLog entity.
  - Store metadata as JSON/null.
  - Capture user_agent from request context when available, or accept a future method signature change if project conventions require explicit user_agent.
  - Emit OTLP attributes following existing fntech-audit pipeline conventions:
    - two_factor.event_type
    - two_factor.method
    - two_factor.user_id
    - two_factor.ip_address
    - two_factor.success
    - two_factor.device_trusted
  - Register ITwoFactorAuditService in TwoFactorServiceProvider.
  - Write unit test: log() persists TwoFactorAuditLog with correct fields.
  - Write unit test: log() emits OTLP attributes.
  - Write unit test: log() accepts null metadata.
  - Write unit test: invalid event type throws InvalidArgumentException.
  - Write unit test: invalid method throws InvalidArgumentException.

### ACCEPTANCE CRITERIA

  - log() persists TwoFactorAuditLog with all required fields.
  - Valid event types are accepted.
  - Invalid event types are rejected.
  - Valid methods are accepted.
  - Invalid methods are rejected.
  - Metadata null is stored as null.
  - Metadata array is JSON-serializable and stored correctly.
  - OTLP attributes match project audit conventions.
  - Service is injectable via ITwoFactorAuditService.
  - All unit tests pass.

### DEVELOPMENT NOTES

  Key files:
  - New: app/Services/Auth/ITwoFactorAuditService.php
  - New: app/Services/Auth/TwoFactorAuditService.php
  - New: tests/Unit/TwoFactorAuditServiceTest.php
  - Modified: app/Providers/TwoFactorServiceProvider.php

### Gotchas:
  - This service is a primitive. It should not know about UserController::verify2FA(), verify2FARecovery(), resend2FA(), or concrete MFA flow ordering.
  - Do not add controller/strategy integration tests here. Integration belongs in Ticket 9/10.
  - Follow existing audit pipeline patterns rather than inventing a new OTLP abstraction.

### Risks:
  - Risk: audit service becomes a dumping ground for MFA orchestration. Mitigation: keep API limited to log().

### Out of scope: 
Controller wiring, strategy wiring, device-trust wiring, Elastic dashboards, audit UI, retention policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added audit logging for two-factor authentication events, including tracking of authentication methods, client IP addresses, and optional metadata.
  * Integrated with OpenTelemetry for enhanced observability when enabled.

* **Tests**
  * Added comprehensive unit tests covering audit log persistence, telemetry emission, and validation of event types and methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenStackweb/openstackid/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->