### PR TITLE
Feature | MFAGateService (Two-Factor Gate Decision Service)

### DIFF
--- a/app/Services/Auth/ITwoFactorGateService.php
+++ b/app/Services/Auth/ITwoFactorGateService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\Auth;
+
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Auth\User;
+
+/**
+ * Interface ITwoFactorGateService
+ * @package App\Services\Auth
+ */
+interface ITwoFactorGateService
+{
+    /**
+     * Determines whether the given user must complete a 2FA challenge for the current login attempt.
+     * Pure decision — no session writes, no OTP generation, no persistence side effects.
+     *
+     * Infrastructure exceptions from the underlying device-trust check are not caught and propagate to the caller.
+     */
+    public function requiresChallenge(User $user, ?string $cookieToken): bool;
+}

--- a/app/Services/Auth/MFAGateService.php
+++ b/app/Services/Auth/MFAGateService.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Services\Auth;
+
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use Auth\User;
+
+/**
+ * Class MFAGateService
+ * @package App\Services\Auth
+ */
+final class MFAGateService implements ITwoFactorGateService
+{
+    public function __construct(
+        private readonly IDeviceTrustService $deviceTrustService
+    ) {
+    }
+
+    public function requiresChallenge(User $user, ?string $cookieToken): bool
+    {
+        if (!$user->shouldRequire2FA()) {
+            return false;
+        }
+        return !$this->deviceTrustService->isDeviceTrusted($user, $cookieToken);
+    }
+}

--- a/app/Services/Auth/TwoFactorServiceProvider.php
+++ b/app/Services/Auth/TwoFactorServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace App\Services\Auth;
+
 /**
  * Copyright 2025 OpenStack Foundation
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,6 +33,7 @@ final class TwoFactorServiceProvider extends ServiceProvider implements Deferrab
     {
         $this->app->singleton(IDeviceTrustService::class, DeviceTrustService::class);
         $this->app->singleton(ITwoFactorAuditService::class, TwoFactorAuditService::class);
+        $this->app->singleton(ITwoFactorGateService::class, MFAGateService::class);
     }
 
     public function provides(): array
@@ -38,6 +41,7 @@ final class TwoFactorServiceProvider extends ServiceProvider implements Deferrab
         return [
             IDeviceTrustService::class,
             ITwoFactorAuditService::class,
+            ITwoFactorGateService::class,
         ];
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,7 @@
       <file>./tests/Unit/MFA/EmailOTPMFAChallengeStrategyTest.php</file>
       <file>./tests/Unit/MFA/MFAChallengeStrategyFactoryTest.php</file>
       <file>./tests/Unit/TwoFactorAuditServiceTest.php</file>
+      <file>./tests/Unit/MFAGateServiceTest.php</file>
     </testsuite>
   </testsuites>
   <php>

--- a/tests/Unit/MFAGateServiceTest.php
+++ b/tests/Unit/MFAGateServiceTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Unit;
+
+/**
+ * Copyright 2025 OpenStack Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+use App\Services\Auth\IDeviceTrustService;
+use App\Services\Auth\MFAGateService;
+use Auth\User;
+use Mockery;
+use Tests\TestCase;
+use Mockery\MockInterface;
+
+/**
+ * Class MFAGateServiceTest
+ * @package Tests\Unit
+ */
+final class MFAGateServiceTest extends TestCase
+{
+    private MFAGateService $service;
+
+    private MockInterface&IDeviceTrustService $deviceTrustService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->deviceTrustService = Mockery::mock(IDeviceTrustService::class);
+        $this->service = new MFAGateService($this->deviceTrustService);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-admin/non-enforced user with 2FA disabled returns false
+    // -------------------------------------------------------------------------
+
+    public function testRequiresChallengeReturnsFalseWhenUserDoesNotRequire2FA(): void
+    {
+        $user = Mockery::mock(User::class);
+        $user->shouldReceive('shouldRequire2FA')->once()->andReturn(false);
+        $this->deviceTrustService->shouldNotReceive('isDeviceTrusted');
+
+        $this->assertFalse($this->service->requiresChallenge($user, null));
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin/enforced user with no cookie returns true
+    // -------------------------------------------------------------------------
+
+    public function testRequiresChallengeReturnsTrueWhenEnforcedAndNoCookie(): void
+    {
+        $user = Mockery::mock(User::class);
+        $user->shouldReceive('shouldRequire2FA')->once()->andReturn(true);
+        $this->deviceTrustService->shouldReceive('isDeviceTrusted')->once()->with($user, null)->andReturn(false);
+
+        $this->assertTrue($this->service->requiresChallenge($user, null));
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin/enforced user with trusted device returns false
+    // -------------------------------------------------------------------------
+
+    public function testRequiresChallengeReturnsFalseWhenEnforcedAndDeviceTrusted(): void
+    {
+        $user = Mockery::mock(User::class);
+        $user->shouldReceive('shouldRequire2FA')->once()->andReturn(true);
+        $this->deviceTrustService->shouldReceive('isDeviceTrusted')->once()->with($user, 'valid-token')->andReturn(true);
+
+        $this->assertFalse($this->service->requiresChallenge($user, 'valid-token'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Admin/enforced user with expired/revoked/wrong device returns true
+    // -------------------------------------------------------------------------
+
+    public function testRequiresChallengeReturnsTrueWhenEnforcedAndDeviceNotTrusted(): void
+    {
+        $user = Mockery::mock(User::class);
+        $user->shouldReceive('shouldRequire2FA')->once()->andReturn(true);
+        $this->deviceTrustService->shouldReceive('isDeviceTrusted')->once()->with($user, 'expired-token')->andReturn(false);
+
+        $this->assertTrue($this->service->requiresChallenge($user, 'expired-token'));
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty-string cookie is forwarded as-is (not coerced to null) and treated
+    // as untrusted — documents the ?string contract between gate and trust layers
+    // -------------------------------------------------------------------------
+
+    public function testRequiresChallengePassesThroughEmptyStringCookieToDeviceTrustService(): void
+    {
+        $user = Mockery::mock(User::class);
+        $user->shouldReceive('shouldRequire2FA')->once()->andReturn(true);
+        $this->deviceTrustService->shouldReceive('isDeviceTrusted')->once()->with($user, '')->andReturn(false);
+
+        $this->assertTrue($this->service->requiresChallenge($user, ''));
+    }
+}


### PR DESCRIPTION
## Task

Ref.: https://app.clickup.com/t/86ba2zfj8

## Changes

### New files

  - `app/Services/Auth/ITwoFactorGateService.php` — Interface defining `requiresChallenge(User $user, ?string $cookieToken): bool`. Pure decision contract with no side effects.
  - `app/Services/Auth/MFAGateService.php` — Concrete implementation. Returns `true` only when the user requires 2FA **and** the device is not trusted (delegates to `IDeviceTrustService`).
  - `tests/Unit/MFAGateServiceTest.php` — 5 unit tests covering: 2FA not required, enforced with no cookie, trusted device, untrusted/expired device, and empty-string cookie passthrough.

  ### Modified files

  - `app/Services/Auth/TwoFactorServiceProvider.php` — Registers `ITwoFactorGateService → MFAGateService` as a singleton.
  - `phpunit.xml` — Adds `MFAGateServiceTest` to the *Two Factor Authentication Test Suite*.

--- 

## Requested GOAL

### Current state

No service exists to determine whether a given login attempt requires a 2FA challenge.

### Target state

MFAGateService implements a pure-decision method requiresChallenge(User $user, ?string $cookieToken): bool. It evaluates user policy and trusted-device state without writing session data, issuing OTPs, or modifying persistence.

### TASKS

  - Create ITwoFactorGateService interface with:
    - requiresChallenge(User $user, ?string $cookieToken): bool
  - Implement MFAGateService.
  - requiresChallenge() logic:
    - if !$user->shouldRequire2FA(), return false
    - if user requires 2FA, call IDeviceTrustService::isDeviceTrusted($user, $cookieToken)
    - return false when device is trusted
    - return true when device is not trusted
  - Register ITwoFactorGateService in TwoFactorServiceProvider.
  - Write unit test: non-admin/non-enforced user with 2FA disabled returns false.
  - Write unit test: admin/enforced user with no cookie returns true.
  - Write unit test: admin/enforced user with trusted device returns false.
  - Write unit test: admin/enforced user with expired/revoked/wrong device returns true.

### ACCEPTANCE CRITERIA

  - requiresChallenge() returns false for users who do not require 2FA.
  - requiresChallenge() returns true for users who require 2FA and have no valid trusted device.
  - requiresChallenge() returns false for users who require 2FA and have valid trusted device.
  - Method has zero side effects.
  - Method does not read cookies directly.
  - Method does not write session.
  - Method does not generate OTP.
  - Method does not persist data directly.
  - Service is injectable via ITwoFactorGateService.
  - All unit tests pass.

### DEVELOPMENT NOTES

#### Key files:
  - New: app/Services/Auth/ITwoFactorGateService.php
  - New: app/Services/Auth/MFAGateService.php
  - New: tests/Unit/MFAGateServiceTest.php
  - Modified: app/Providers/TwoFactorServiceProvider.php

#### Gotchas:
  - This service is intentionally boring. Keep it as a decision point.
  - Cookie reading belongs to MFACookieManager in the controller layer.
  - Trusted-device validation belongs to DeviceTrustService.

#### Risks:
  - Risk: gate service starts mutating session or persistence. Mitigation: unit tests should assert only decision behavior and mocked service calls.

#### Out of scope: 
Issuing challenges, reading HTTP request, queueing cookies, rate limiting, audit logging.